### PR TITLE
Feat/eager load

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "4.1.0-31",
+  "version": "4.1.0-32",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "4.1.0-27",
+  "version": "4.1.0-28",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "4.1.0-29",
+  "version": "4.1.0-30",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "4.1.0-32",
+  "version": "4.1.0-33",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "4.1.0-28",
+  "version": "4.1.0-29",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "4.1.0-30",
+  "version": "4.1.0-31",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/src/Collection/helpers.js
+++ b/src/Collection/helpers.js
@@ -1,0 +1,99 @@
+import { sanitizedRaw } from "../RawRecord"
+
+function buildAdjacencyList(relationships) {
+  const adjacencyList = {}
+
+  relationships.forEach(({ from, info, to }) => {
+    if (!adjacencyList[from]) adjacencyList[from] = []
+    adjacencyList[from].push({ to, ...info })
+  })
+
+  return adjacencyList
+}
+
+function buildHierarchy(rootTable, results, adjacencyList, database) {
+  const hierarchy = {} // Map of id to data
+
+  // Function to recursively build the tree
+  const buildTree = (item, tableName) => {
+    const relations = adjacencyList[tableName] || []
+
+    relations.forEach(({ to, key, foreignKey, type }) => {
+      const linkKey = type === 'belongs_to' ? key : foreignKey
+      const relatedItems = results
+        .filter((data) => data[linkKey] === item.id)
+        .map((data) => {
+          const relatedItemId = data[`${to}.id`]
+          if (!relatedItemId) return null // Skip invalid records
+
+          let relatedItem = hierarchy[relatedItemId] || { ...data }
+
+          // Ensure relatedItem is in the hierarchy
+          if (!hierarchy[relatedItemId]) {
+            hierarchy[relatedItemId] = relatedItem
+          }
+
+          return relatedItem
+        })
+        .filter((item) => item !== null) // Filter out null values
+
+      if (relatedItems.length > 0) {
+        item[to] = relatedItems
+        relatedItems.forEach((relatedItem) => buildTree(relatedItem, to))
+      }
+    })
+  }
+
+  // Initialize the hierarchy with the results
+  results.forEach((row) => {
+    const tableName =
+      Object.keys(adjacencyList).find((table) => row[`${table}.id`]) ||
+      rootTable
+    const id = row[`${tableName}.id`]
+
+    if (id) {
+      hierarchy[id] = hierarchy[id] || { ...row }
+    }
+  })
+
+  // Start building the tree from the root table
+  const rootData = Object.values(hierarchy).filter(
+    (item) => item[`${rootTable}.id`]
+  )
+
+  rootData.forEach((item) => buildTree(item, rootTable))
+
+  // Function to sanitize item
+  const sanitizeItem = (item, tableName) => {
+    const relatedTables = new Set(
+      (adjacencyList[tableName] || []).map(({ to }) => to)
+    )
+
+    const collection = database.collections.get(tableName)
+    const ModelClass = collection.modelClass
+    const sanitized = sanitizedRaw(item, database.schema.tables[tableName], true)
+    const sanitizedItem = new ModelClass(collection, sanitized)
+
+    relatedTables.forEach((relatedTable) => {
+      const relatedItems = item[relatedTable] || []
+      sanitizedItem[relatedTable] = relatedItems.map((relatedItem) =>
+        sanitizeItem(relatedItem, relatedTable)
+      )
+    })
+
+    return sanitizedItem
+  }
+
+  const sanitizedRootData = rootData.map((item) =>
+    sanitizeItem(item, rootTable)
+  )
+
+  return sanitizedRootData
+}
+
+export function mapToGraph(results, relationships, collection) {
+  const adjacencyList = buildAdjacencyList(relationships)
+  const rootTable = collection.table
+
+  return buildHierarchy(rootTable, results, adjacencyList, collection.database)
+}

--- a/src/Query/helpers.js
+++ b/src/Query/helpers.js
@@ -12,7 +12,9 @@ export const getAssociations = (
   modelClass: Class<Model>,
   db: Database,
 ): QueryAssociation[] =>
-  description.joinTables
+  description.joinTables.concat(description.eagerJoinTables
+    .map(({ joinTables }) => joinTables))
+    .reduce((acc, tables) => acc.concat(tables), [])
     .map(table => {
       const info = modelClass.associations[table]
       invariant(
@@ -22,7 +24,10 @@ export const getAssociations = (
       return { from: modelClass.table, to: table, info }
     })
     .concat(
-      description.nestedJoinTables.map(({ from, to }) => {
+      description.nestedJoinTables.concat(description.eagerJoinTables
+      .map(({ nestedJoinTables }) => nestedJoinTables))
+      .reduce((acc, tables) => acc.concat(tables), [])
+      .map(({ from, to }) => {
         const collection = db.get(from)
         invariant(
           collection,

--- a/src/Query/index.js
+++ b/src/Query/index.js
@@ -80,6 +80,7 @@ export default class Query<Record: Model> {
       skip,
       joinTables,
       nestedJoinTables,
+      // todo add eagerJoinTables
       lokiFilter,
     } = this._rawDescription
 

--- a/src/QueryDescription/index.d.ts
+++ b/src/QueryDescription/index.d.ts
@@ -69,6 +69,16 @@ declare module '@BuildHero/watermelondb/QueryDescription' {
     type: 'joinTables'
     tables: TableName<any>[]
   }
+  export interface NestedJoin {
+    type: 'nestedJoinTable'
+    from: TableName<any>
+    to: TableName<any>
+  }
+  export interface EagerJoin {
+    type: 'eagerJoinTables'
+    joins: Join[]
+    nestedJoins: NestedJoin[]
+  }
   export interface SqlQuery {
     type: 'sqlQuery'
     sql: string
@@ -80,7 +90,7 @@ declare module '@BuildHero/watermelondb/QueryDescription' {
     cte: string
   }
 
-  export type Clause = Where | On | SortBy | Take | Skip | Join | SqlQuery
+  export type Clause = Where | On | SortBy | Take | Skip | Join | SqlQuery | SqlCTE | EagerJoin
   export interface QueryDescription {
     where: Where[]
     join: On[]
@@ -110,8 +120,9 @@ declare module '@BuildHero/watermelondb/QueryDescription' {
   export function experimentalSortBy(sortColumn: ColumnName, sortOrder?: SortOrder): SortBy
   export function experimentalTake(count: number): Take
   export function experimentalSkip(count: number): Skip
+  export function eager(...joins: Join[]|NestedJoin[]): EagerJoin
   export function experimentalJoinTables(tables: TableName<any>[]): Join
-  export function experimentalNestedJoin(from: string, to: string)
+  export function experimentalNestedJoin(from: string, to: string): NestedJoin
   export function sanitizeLikeString(value: string): string
   export function unsafeSqlQuery(value: string): SqlQuery
   export function asUnsafeSql(value: string): SqlCTE

--- a/src/adapters/sqlite/index.js
+++ b/src/adapters/sqlite/index.js
@@ -209,7 +209,7 @@ export default class SQLiteAdapter implements DatabaseAdapter, SQLDatabaseAdapte
 
   query(query: SerializedQuery, callback: ResultCallback<CachedQueryResult>): void {
     validateTable(query.table, this.schema)
-    this.unsafeSqlQuery(query.table, encodeQuery(query), callback)
+    this.unsafeSqlQuery(query.table, encodeQuery(query, false, this.schema), callback)
   }
 
   execSqlQuery(sql: string, params: any[], callback: ResultCallback<CachedQueryResult>): void {


### PR DESCRIPTION
Adds new QueryDescriptor called `eager` than can be used like this.

```
 const visits = await database.collections
      .get('visits')
      .query(
        Q.where('id', visit.id),
        Q.eager(
          Q.experimentalJoinTables(['jobs']),
          Q.experimentalNestedJoin('jobs', 'customer_properties'),
          Q.experimentalNestedJoin('jobs', 'service_agreements'),
          Q.experimentalNestedJoin('customer_properties', 'company_addresses')
        )
      )
      .fetch()


    console.log('jobs', visits[0].jobs)


// outputs
/*
jobs [{"__changes": null, "_hasPendingDelete": false, "_hasPendingUpdate": false, "_isCommitted": true, "_isEditing": false, "_raw": {"_changed": "", "_status": "synced", "id": "fa114969-427c-433e-ba86-4cf28d244058", "jobs._deleted": null, "jobs._last_changed_at": null, "jobs._version": null, "jobs.accounting_ref_id": null, "jobs.amount_not_to_exceed": 1000, "jobs.amount_quoted": 982, "jobs.authorized_by_id": "44d76ae3-8829-4372-ad2c-9402504fc4e6", "jobs.automated_procurement_status": "No POs", "jobs.automated_quote_status": null, "jobs.best_contact": null, "jobs.billing_customer_id": "04c99c32-1f10-4df7-a21d-2ec8528cc477", "jobs.billing_customer_name": "Adelina", "jobs.blanket_po_id": null, "jobs.completed_date": null, "jobs.cost_amount": 500, "jobs.created_at": 0, "jobs.created_by": "Kostya Kisil (impersonated by christianmartinez m)", "jobs.created_date": null, "jobs.created_date_time": "1726266514561", "jobs.custom_identifier": "24-JR5434", "jobs.customer_id": "04c99c32-1f10-4df7-a21d-2ec8528cc477", "jobs.customer_name": "Adelina", "jobs.customer_property_id": "25548580-cad9-4620-b4e3-8bec5a01101d", "jobs.customer_property_name": "Forties", "jobs.customer_property_sort_key": null, "jobs.customer_property_type_name": null, "jobs.customer_provided_job_number": null, "jobs.customer_provided_po_number": null, "jobs.customer_provided_wo_number": "123", "jobs.customer_rep_name": null, "jobs.customer_rep_sort_key": null, "jobs.customer_sort_key": null, "jobs.deleted_by": null, "jobs.deleted_date": null, "jobs.deleted_date_time": null, "jobs.detailed_job_costing_enabled": null, "jobs.due_date": null, "jobs.entity_type": "Job", "jobs.hierarchy": "003076ba-04aa-4ce8-aec1-e5e5c7b66ccf_5b4998f0-cddc-4823-88b4-7c33d1b27201_04c99c32-1f10-4df7-a21d-2ec8528cc477_25548580-cad9-4620-b4e3-8bec5a01101d", "jobs.intacct_location_id": null, "jobs.is_flagged": null, "jobs.issue_description": "This is a issue description", "jobs.job_number": "5583", "jobs.job_type_id": "9e0eb08a-ea04-4cd0-abc4-8b3a898de910", "jobs.job_type_internal": null, "jobs.job_type_name": "PT&M", "jobs.last_updated_by": "Kostya Kisil (impersonated by christianmartinez m)", "jobs.last_updated_date": null, "jobs.last_updated_date_time": "1726266569654", "jobs.maintenance_template_id": null, "jobs.manual_quote_status": null, "jobs.num_visits_computed": null, "jobs.outstanding_balance_computed": null, "jobs.overdue_balance_computed": null, "jobs.owner_id": "455067b4-c980-4019-8e0b-ac0e7e4d019f", "jobs.parent_id": "25548580-cad9-4620-b4e3-8bec5a01101d", "jobs.parent_sort_key": null, "jobs.partition_key": "003076ba-04aa-4ce8-aec1-e5e5c7b66ccf", "jobs.preferred_technician_id": "69f8fcdf-2996-4904-94d6-d87e41abfaf1", "jobs.price_book_id": "1861b4a9-5605-43b9-a7ee-f84c4f2ac585", "jobs.priority": "NORMAL", "jobs.procurement_status": null, "jobs.quote_id": null, "jobs.service_agreement_id": null, "jobs.sort_key": "003076ba-04aa-4ce8-aec1-e5e5c7b66ccf_5b4998f0-cddc-4823-88b4-7c33d1b27201_04c99c32-1f10-4df7-a21d-2ec8528cc477_25548580-cad9-4620-b4e3-8bec5a01101d_Job_fa114969-427c-433e-ba86-4cf28d244058", "jobs.status": "Open", "jobs.tenant_company_id": "5b4998f0-cddc-4823-88b4-7c33d1b27201", "jobs.tenant_id": "003076ba-04aa-4ce8-aec1-e5e5c7b66ccf", "jobs.total_billed_job_computed": null, "jobs.total_budgeted_hours": 30, "jobs.updated_at": 0, "jobs.version": 1, "jobs.work_type_id": null}, "_subscribers": [], "collection": {"_cache": [RecordCache], "_subscribers": [Array], "changes": [Subject], "database": [Database], "modelClass": [Function Job]}, "customer_properties": [[CustomerProperty]], "service_agreements": []}]

*/
```