### PR TITLE
chore: use map instead of js object - MOBILE-2213

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "4.1.0-138",
+  "version": "4.1.0-139",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "4.1.0-139",
+  "version": "4.1.0-140",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "4.1.0-137",
+  "version": "4.1.0-138",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "4.1.0-134",
+  "version": "4.1.0-135",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "4.1.0-140",
+  "version": "4.1.0-141",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "4.1.0-135",
+  "version": "4.1.0-136",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "4.1.0-136",
+  "version": "4.1.0-137",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/src/Database/index.js
+++ b/src/Database/index.js
@@ -99,11 +99,6 @@ export default class Database {
           return
         }
 
-        /* invariant(
-          !record._isCommitted || record._hasPendingUpdate || record._hasPendingDelete,
-          `Cannot batch a record that doesn't have a prepared create or prepared update`,
-        ) */
-
         const raw = record._raw
         const { id } = raw // faster than Model.id
         const { table } = record.constructor // faster than Model.table

--- a/src/sync/impl/applyRemote.js
+++ b/src/sync/impl/applyRemote.js
@@ -171,7 +171,7 @@ const getAllRecordsToApply = (
   const promises = [] 
   
   for (const [tableName, changes] of remoteChanges.entries()) {
-    const collection = (db as any).get(tableName)
+    const collection = db.get(tableName)
 
     if (!collection) {
       logger.warn(

--- a/src/sync/impl/applyRemote.js
+++ b/src/sync/impl/applyRemote.js
@@ -170,7 +170,7 @@ const getAllRecordsToApply = (
 ): Promise<Map<string, any>> => {
   const promises = Array.from(remoteChanges.entries()).map(
     async ([tableName, changes]) => {
-      const collection = db.get(tableName as TableName<any>);
+      const collection = db.get(tableName);
 
       if (!collection) {
         logger.warn(

--- a/src/sync/impl/helpers.js
+++ b/src/sync/impl/helpers.js
@@ -117,7 +117,8 @@ export function ensureSameDatabase(database: Database, initialResetCount: number
   )
 }
 
-export const isChangeSetEmpty: SyncDatabaseChangeSet => boolean = pipe(
-  values,
-  all(({ created, updated, deleted }) => created.length + updated.length + deleted.length === 0),
-)
+export function isChangeSetEmpty(changeSet: Map): boolean = {
+  return Array.from(changeSet.values()).every((tableChangeSet) => {
+    return tableChangeSet.created.length === 0 && tableChangeSet.updated.length === 0 && tableChangeSet.deleted.length === 0;
+  })
+}

--- a/src/sync/impl/helpers.js
+++ b/src/sync/impl/helpers.js
@@ -117,8 +117,7 @@ export function ensureSameDatabase(database: Database, initialResetCount: number
   )
 }
 
-export function isChangeSetEmpty(changeSet: Map): boolean {
-  return Array.from(changeSet.values()).every((tableChangeSet) => {
-    return tableChangeSet.created.length === 0 && tableChangeSet.updated.length === 0 && tableChangeSet.deleted.length === 0;
-  })
-}
+export const isChangeSetEmpty: SyncDatabaseChangeSet => boolean = pipe(
+  values,
+  all(({ created, updated, deleted }) => created.length + updated.length + deleted.length === 0),
+)

--- a/src/sync/impl/helpers.js
+++ b/src/sync/impl/helpers.js
@@ -117,7 +117,7 @@ export function ensureSameDatabase(database: Database, initialResetCount: number
   )
 }
 
-export function isChangeSetEmpty(changeSet: Map): boolean = {
+export function isChangeSetEmpty(changeSet: Map): boolean {
   return Array.from(changeSet.values()).every((tableChangeSet) => {
     return tableChangeSet.created.length === 0 && tableChangeSet.updated.length === 0 && tableChangeSet.deleted.length === 0;
   })

--- a/src/sync/index.d.ts
+++ b/src/sync/index.d.ts
@@ -7,7 +7,7 @@ declare module '@BuildHero/watermelondb/sync' {
     updated: DirtyRaw[]
     deleted: RecordId[]
   }
-  export type SyncDatabaseChangeSet = { [table: string]: SyncTableChangeSet }
+  export type SyncDatabaseChangeSet = Map<string, SyncTableChangeSet>
 
   export type SyncLocalChanges = { changes: SyncDatabaseChangeSet; affectedRecords: Model[] }
 

--- a/src/sync/index.js
+++ b/src/sync/index.js
@@ -25,7 +25,7 @@ export type SyncTableChangeSet = $Exact<{
   updated: DirtyRaw[],
   deleted: RecordId[],
 }>
-export type SyncDatabaseChangeSet = $Exact<{ [TableName<any>]: SyncTableChangeSet }>
+export type SyncDatabaseChangeSet = Map<String, SyncTableChangeSet>
 
 export type SyncLocalChanges = $Exact<{ changes: SyncDatabaseChangeSet, affectedRecords: Model[] }>
 


### PR DESCRIPTION
in order for use to drop custom hermes we need to make sure sync manager and watermelon are using a map instead of vanilla object ({}) to prevent property limit exceeded exceptions.