### PR TITLE
Fix/mobile 2503

### DIFF
--- a/native/android/src/main/cpp/JSIAndroidBridgeWrapper.cpp
+++ b/native/android/src/main/cpp/JSIAndroidBridgeWrapper.cpp
@@ -116,8 +116,6 @@ namespace watermelondb {
 
         env->CallVoidMethod(bridge_, releaseConnectionMethod, jTag);
 
-        finalizeStmt(stmt);
-
         return arrayFromStd(*runtime_, records);
     }
 
@@ -196,8 +194,6 @@ namespace watermelondb {
         }
 
         env->CallVoidMethod(bridge_, releaseConnectionMethod, jTag);
-
-        finalizeStmt(stmt);
 
         return arrayFromStd(*runtime_, records);
     }


### PR DESCRIPTION
Android does not need the explicit finalized step since we are already calling the release connection function which performs its own garbage collection. By doing finalize also, it is leading to odd race conditions. 