### PR TITLE
fix(android): retry on SQLiteDatabaseLockedException during connection init - MOBILE-5065

### DIFF
--- a/native/android/src/androidTest/java/com/nozbe/watermelondb/DatabaseTest.kt
+++ b/native/android/src/androidTest/java/com/nozbe/watermelondb/DatabaseTest.kt
@@ -5,15 +5,20 @@ import androidx.test.core.app.ApplicationProvider
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
 @RunWith(AndroidJUnit4::class)
 class DatabaseTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
     private var db: Database? = null
+    private val extraDbs = mutableListOf<Database>()
 
     private fun makeDatabase(): Database {
         val database = Database("wmdb-test-${System.nanoTime()}", context)
@@ -21,10 +26,18 @@ class DatabaseTest {
         return database
     }
 
+    private fun makeDatabaseWithName(name: String): Database {
+        val database = Database(name, context)
+        extraDbs.add(database)
+        return database
+    }
+
     @After
     fun tearDown() {
         db?.close()
         db = null
+        extraDbs.forEach { it.close() }
+        extraDbs.clear()
     }
 
     @Test
@@ -138,5 +151,177 @@ class DatabaseTest {
         assertEquals("writer", database._test_readDatabaseIdentity(
             "SELECT * FROM products WHERE name = 'temp.file'"
         ))
+    }
+
+    // -- SQLite connection contention (reproduces HeadlessJS dual-connection scenario) --
+
+    /**
+     * Reproduces the production SQLiteDatabaseLockedException:
+     *
+     * Two separate Database instances open the same SQLite file (simulating the
+     * main app thread and a HeadlessJS background sync thread on Android).
+     * One holds a long write transaction while the other tries to write.
+     *
+     * Without PRAGMA busy_timeout, the second connection throws immediately
+     * (or after requery's short internal default). With busy_timeout=3000,
+     * SQLite retries internally and succeeds once the first transaction commits.
+     *
+     * The hold time must exceed requery's built-in default (~2.5s) to reproduce
+     * the production scenario where large sync transactions hold locks longer.
+     */
+    @Test(timeout = 30000)
+    fun concurrentWritersWithBusyTimeoutDoNotThrow() {
+        val sharedName = "wmdb-contention-${System.nanoTime()}"
+
+        // Two separate Database instances on the same file — same as HeadlessJS scenario
+        val db1 = makeDatabaseWithName(sharedName)
+        val db2 = makeDatabaseWithName(sharedName)
+
+        // Setup: create table via db1
+        db1.execute("CREATE TABLE IF NOT EXISTS test_contention (id TEXT PRIMARY KEY, value TEXT)")
+
+        val writerStarted = CountDownLatch(1)
+        val writerDone = CountDownLatch(1)
+        val db2Error = AtomicReference<Throwable?>(null)
+        val db2Done = CountDownLatch(1)
+
+        // Thread 1: hold a write transaction long enough to exceed any built-in
+        // busy timeout in the requery SQLite wrapper (~2.5s). In production, sync
+        // transactions routinely hold locks for 5-10+ seconds on large tenants.
+        val writerThread = Thread {
+            try {
+                db1.transaction {
+                    for (i in 1..500) {
+                        db1.execute(
+                            "INSERT OR REPLACE INTO test_contention (id, value) VALUES (?, ?)",
+                            arrayOf("bg-sync-$i", "background-data-$i")
+                        )
+                    }
+                    writerStarted.countDown()
+                    Thread.sleep(4000)
+                }
+            } finally {
+                writerDone.countDown()
+            }
+        }
+
+        // Thread 2: try to write while thread 1 holds the lock (simulates foreground user action)
+        val readerThread = Thread {
+            try {
+                writerStarted.await(10, TimeUnit.SECONDS)
+                Thread.sleep(50)
+
+                // Without busy_timeout this throws SQLiteDatabaseLockedException
+                // once the built-in requery timeout (~2.5s) is exhausted.
+                db2.transaction {
+                    db2.execute(
+                        "INSERT OR REPLACE INTO test_contention (id, value) VALUES (?, ?)",
+                        arrayOf("fg-action-1", "foreground-data")
+                    )
+                }
+            } catch (e: Throwable) {
+                db2Error.set(e)
+            } finally {
+                db2Done.countDown()
+            }
+        }
+
+        writerThread.start()
+        readerThread.start()
+
+        assertTrue("Writer thread timed out", writerDone.await(20, TimeUnit.SECONDS))
+        assertTrue("Reader thread timed out", db2Done.await(20, TimeUnit.SECONDS))
+
+        // With busy_timeout=3000, db2 should have waited for db1 to commit — no error
+        assertNull(
+            "Expected no error with busy_timeout but got: ${db2Error.get()?.message}",
+            db2Error.get()
+        )
+
+        // Verify both writes landed
+        val cursor = db1.rawQuery(
+            "SELECT COUNT(*) as count FROM test_contention",
+            emptyArray()
+        )
+        cursor.use {
+            it.moveToFirst()
+            assertEquals(501, it.getInt(it.getColumnIndex("count")))
+        }
+    }
+
+    /**
+     * Verifies that a foreground read doesn't throw while a background write
+     * transaction is in progress. This is the most common production scenario:
+     * user taps a visit while background sync is writing.
+     */
+    @Test
+    fun concurrentReadDuringWriteDoesNotThrow() {
+        val sharedName = "wmdb-read-contention-${System.nanoTime()}"
+
+        val db1 = makeDatabaseWithName(sharedName)
+        val db2 = makeDatabaseWithName(sharedName)
+
+        // Setup
+        db1.execute("CREATE TABLE IF NOT EXISTS test_reads (id TEXT PRIMARY KEY, value TEXT)")
+        db1.execute(
+            "INSERT INTO test_reads (id, value) VALUES (?, ?)",
+            arrayOf("existing-1", "data")
+        )
+
+        val writerStarted = CountDownLatch(1)
+        val writerDone = CountDownLatch(1)
+        val readerError = AtomicReference<Throwable?>(null)
+        val readerDone = CountDownLatch(1)
+
+        // Thread 1: long write transaction (background sync)
+        val writerThread = Thread {
+            try {
+                db1.transaction {
+                    for (i in 1..100) {
+                        db1.execute(
+                            "INSERT OR REPLACE INTO test_reads (id, value) VALUES (?, ?)",
+                            arrayOf("sync-$i", "sync-data-$i")
+                        )
+                    }
+                    writerStarted.countDown()
+                    Thread.sleep(500)
+                }
+            } finally {
+                writerDone.countDown()
+            }
+        }
+
+        // Thread 2: read while write is in progress (user tapping a visit)
+        val readerThread = Thread {
+            try {
+                writerStarted.await(5, TimeUnit.SECONDS)
+                Thread.sleep(50)
+
+                // Read via the reader connection — should work with WAL + busy_timeout
+                val cursor = db2.rawQuery(
+                    "SELECT value FROM test_reads WHERE id = ?",
+                    arrayOf("existing-1")
+                )
+                cursor.use {
+                    it.moveToFirst()
+                    assertEquals("data", it.getString(0))
+                }
+            } catch (e: Throwable) {
+                readerError.set(e)
+            } finally {
+                readerDone.countDown()
+            }
+        }
+
+        writerThread.start()
+        readerThread.start()
+
+        assertTrue("Writer timed out", writerDone.await(10, TimeUnit.SECONDS))
+        assertTrue("Reader timed out", readerDone.await(10, TimeUnit.SECONDS))
+
+        assertNull(
+            "Read during write should not throw: ${readerError.get()?.message}",
+            readerError.get()
+        )
     }
 }

--- a/native/android/src/androidTest/java/com/nozbe/watermelondb/DatabaseTest.kt
+++ b/native/android/src/androidTest/java/com/nozbe/watermelondb/DatabaseTest.kt
@@ -162,9 +162,10 @@ class DatabaseTest {
      * main app thread and a HeadlessJS background sync thread on Android).
      * One holds a long write transaction while the other tries to write.
      *
-     * Without PRAGMA busy_timeout, the second connection throws immediately
-     * (or after requery's short internal default). With busy_timeout=3000,
-     * SQLite retries internally and succeeds once the first transaction commits.
+     * Without openWithRetry, the second connection throws immediately when
+     * sqlite3_prepare_v2() hits SQLITE_BUSY during PRAGMA compilation (the
+     * busy handler is NOT invoked at the prepare level). openWithRetry retries
+     * the entire open+PRAGMA block at the application level for up to 5s.
      *
      * The hold time must exceed requery's built-in default (~2.5s) to reproduce
      * the production scenario where large sync transactions hold locks longer.
@@ -211,8 +212,8 @@ class DatabaseTest {
                 writerStarted.await(10, TimeUnit.SECONDS)
                 Thread.sleep(50)
 
-                // Without busy_timeout this throws SQLiteDatabaseLockedException
-                // once the built-in requery timeout (~2.5s) is exhausted.
+                // Without openWithRetry this throws SQLiteDatabaseLockedException
+                // once requery's built-in timeout (~2.5s) is exhausted.
                 db2.transaction {
                     db2.execute(
                         "INSERT OR REPLACE INTO test_contention (id, value) VALUES (?, ?)",
@@ -232,9 +233,9 @@ class DatabaseTest {
         assertTrue("Writer thread timed out", writerDone.await(20, TimeUnit.SECONDS))
         assertTrue("Reader thread timed out", db2Done.await(20, TimeUnit.SECONDS))
 
-        // With busy_timeout=3000, db2 should have waited for db1 to commit — no error
+        // openWithRetry retries until db1 commits — no error
         assertNull(
-            "Expected no error with busy_timeout but got: ${db2Error.get()?.message}",
+            "Expected no error with openWithRetry but got: ${db2Error.get()?.message}",
             db2Error.get()
         )
 

--- a/native/android/src/main/cpp/SliceImportDatabaseAdapterAndroid.cpp
+++ b/native/android/src/main/cpp/SliceImportDatabaseAdapterAndroid.cpp
@@ -98,6 +98,7 @@ public:
                 return;
             }
             std::string ignored;
+            execSQL(db_, "PRAGMA busy_timeout=5000;", ignored);
             execSQL(db_, "PRAGMA journal_mode=WAL;", ignored);
             execSQL(db_, "PRAGMA synchronous=NORMAL;", ignored);
             execSQL(db_, "PRAGMA temp_store=MEMORY;", ignored);

--- a/native/android/src/main/java/com/nozbe/watermelondb/Database.kt
+++ b/native/android/src/main/java/com/nozbe/watermelondb/Database.kt
@@ -20,12 +20,13 @@ class Database(private val name: String, private val context: Context) {
     private val transactionDepth = ThreadLocal<Int>()
 
     private val writerDb: SQLiteDatabase by lazy {
-        SQLiteDatabase.openOrCreateDatabase(databasePath, null).also {
-            runPragma(it, "PRAGMA journal_mode=WAL")
-            // Critical performance settings for WAL mode
-            runPragma(it, "PRAGMA synchronous=NORMAL")  // FULL is too slow, NORMAL is safe with WAL
-            runPragma(it, "PRAGMA temp_store=MEMORY")   // Faster temp operations
-            runPragma(it, "PRAGMA mmap_size=268435456") // 256MB memory-mapped I/O
+        openWithRetry {
+            SQLiteDatabase.openOrCreateDatabase(databasePath, null).also {
+                runPragma(it, "PRAGMA journal_mode=WAL")
+                runPragma(it, "PRAGMA synchronous=NORMAL")  // FULL is too slow, NORMAL is safe with WAL
+                runPragma(it, "PRAGMA temp_store=MEMORY")   // Faster temp operations
+                runPragma(it, "PRAGMA mmap_size=268435456") // 256MB memory-mapped I/O
+            }
         }
     }
 
@@ -35,11 +36,13 @@ class Database(private val name: String, private val context: Context) {
         if (isInMemoryPath(databasePath)) {
             writerDb
         } else {
-            SQLiteDatabase.openDatabase(databasePath, null, SQLiteDatabase.OPEN_READONLY).also {
-                try {
-                    runPragma(it, "PRAGMA query_only=1")
-                } catch (_: Exception) {
-                    // Best effort; some builds may not allow setting pragmas on read-only connections.
+            openWithRetry {
+                SQLiteDatabase.openDatabase(databasePath, null, SQLiteDatabase.OPEN_READONLY).also {
+                    try {
+                        runPragma(it, "PRAGMA query_only=1")
+                    } catch (_: Exception) {
+                        // Best effort; some builds may not allow setting pragmas on read-only connections.
+                    }
                 }
             }
         }
@@ -47,6 +50,41 @@ class Database(private val name: String, private val context: Context) {
 
     private fun runPragma(db: SQLiteDatabase, sql: String) {
         db.rawQuery(sql, null).use { /* pragma executed */ }
+    }
+
+    /**
+     * Retry a database open + PRAGMA block on SQLiteDatabaseLockedException.
+     *
+     * sqlite3_prepare_v2() (used by rawQuery to compile PRAGMAs) does NOT
+     * invoke the sqlite3 busy handler — it returns SQLITE_BUSY immediately.
+     * Additionally, the requery connection pool may run internal PRAGMAs
+     * during openOrCreateDatabase() that also fail under lock contention.
+     * We must retry the entire open+configure block at the application level.
+     *
+     * Retries up to 5s with 200ms backoff to match the production scenario
+     * where HeadlessJS background sync transactions hold locks for seconds.
+     */
+    private fun <T> openWithRetry(
+        maxWaitMs: Long = 5000,
+        intervalMs: Long = 200,
+        block: () -> T
+    ): T {
+        val deadline = System.currentTimeMillis() + maxWaitMs
+        var lastException: Exception? = null
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                return block()
+            } catch (e: Exception) {
+                if (e.message?.contains("database is locked") == true ||
+                    e.javaClass.simpleName == "SQLiteDatabaseLockedException") {
+                    lastException = e
+                    Thread.sleep(intervalMs)
+                } else {
+                    throw e
+                }
+            }
+        }
+        throw lastException ?: IllegalStateException("Database open retry exhausted")
     }
 
     var userVersion: Int

--- a/native/ios/WatermelonDB/Database.swift
+++ b/native/ios/WatermelonDB/Database.swift
@@ -290,6 +290,10 @@ public class Database {
     }
     
     private func setWalMode(on db: FMDatabase) throws {
+        // Must be first — if another connection holds a lock, all subsequent
+        // PRAGMAs (including journal_mode) would throw immediately.
+        try db.executeQuery("pragma busy_timeout=5000", values: []).close()
+
         let result = try db.executeQuery("pragma journal_mode=wal", values: [])
         result.close()
 

--- a/native/ios/WatermelonDB/SliceImportDatabaseAdapter.mm
+++ b/native/ios/WatermelonDB/SliceImportDatabaseAdapter.mm
@@ -90,6 +90,7 @@ public:
         cachedDB_ = db;
 
         std::string ignored;
+        execSQL(db, "PRAGMA busy_timeout=5000;", ignored);
         execSQL(db, "PRAGMA journal_mode=WAL;", ignored);
         execSQL(db, "PRAGMA synchronous=NORMAL;", ignored);
         execSQL(db, "PRAGMA temp_store=MEMORY;", ignored);


### PR DESCRIPTION
## Summary

- Fixes `android.database.sqlite.SQLiteDatabaseLockedException` on Android when HeadlessJS background sync holds a write lock while the foreground opens a new database connection
- `sqlite3_prepare_v2()` does NOT invoke the SQLite busy handler — it returns `SQLITE_BUSY` immediately, so `PRAGMA busy_timeout` alone cannot fix this
- Adds `openWithRetry` in `Database.kt` that retries the entire open+PRAGMA block for up to 5s with 200ms backoff
- Adds `PRAGMA busy_timeout=5000` in slice import adapters for `sqlite3_step()`-level contention
- iOS parity changes in `Database.swift` and `SliceImportDatabaseAdapter.mm`

## Test plan

- [x] Android instrumented test `concurrentWritersWithBusyTimeoutDoNotThrow` — reproduces exact HeadlessJS dual-connection scenario, **fails without fix, passes with fix**
- [x] Android instrumented test `concurrentReadDuringWriteDoesNotThrow` — reproduces foreground read during background write
- [x] All 15 existing `DatabaseTest.kt` tests pass
- [ ] Publish new WatermelonDB version and bump in buildhero-mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)