### PR TITLE
fix(sync): cache SyncHttpManager jclass to fix retries on native threads

### DIFF
--- a/native/android/src/main/cpp/SyncPlatformAndroid.cpp
+++ b/native/android/src/main/cpp/SyncPlatformAndroid.cpp
@@ -21,7 +21,22 @@ std::mutex gHttpMutex;
 std::unordered_map<int64_t, std::shared_ptr<HttpCallbackState>> gHttpCallbacks;
 std::atomic<int64_t> gNextHttpHandle{1};
 
+// Cached global ref to com.nozbe.watermelondb.sync.SyncHttpManager.
+//
+// FindClass for app classes only works from threads that descend from a Java
+// caller (so the thread's class loader stack reaches the app loader). Native
+// threads attached via AttachCurrentThread (e.g. retry threads spawned by
+// SyncEngine::scheduleRetryLocked) get the system class loader, which can't
+// see app classes — FindClass returns null and the sync surfaces as
+// "Failed to start HTTP request". We resolve the class once from a Java-side
+// thread and reuse the global ref forever.
+std::atomic<jclass> gSyncHttpManagerClass{nullptr};
+
 jclass getSyncHttpManagerClass(JNIEnv* env) {
+    jclass cached = gSyncHttpManagerClass.load(std::memory_order_acquire);
+    if (cached) {
+        return cached;
+    }
     jclass local = env->FindClass(kSyncHttpManagerClass);
     if (!local) {
         env->ExceptionClear();
@@ -29,6 +44,16 @@ jclass getSyncHttpManagerClass(JNIEnv* env) {
     }
     jclass global = (jclass)env->NewGlobalRef(local);
     env->DeleteLocalRef(local);
+    if (!global) {
+        return nullptr;
+    }
+    jclass expected = nullptr;
+    if (!gSyncHttpManagerClass.compare_exchange_strong(
+            expected, global, std::memory_order_acq_rel, std::memory_order_acquire)) {
+        // Lost the race — another thread cached first; drop our duplicate ref.
+        env->DeleteGlobalRef(global);
+        return expected;
+    }
     return global;
 }
 
@@ -54,7 +79,6 @@ bool callStartRequest(JNIEnv* env,
     }
     jmethodID methodId = getStaticMethod(env, cls, "startRequest", kStartRequestSig);
     if (!methodId) {
-        env->DeleteGlobalRef(cls);
         return false;
     }
 
@@ -84,7 +108,6 @@ bool callStartRequest(JNIEnv* env,
     if (jBody) {
         env->DeleteLocalRef(jBody);
     }
-    env->DeleteGlobalRef(cls);
 
     if (env->ExceptionCheck()) {
         env->ExceptionClear();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "7.0.4-6",
+  "version": "7.0.4-8",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",


### PR DESCRIPTION
## Summary

- Fixes intermittent `Failed to start HTTP request` errors during sync on Android.
- Caches the `SyncHttpManager` `jclass` as a global JNI ref so `FindClass` is only called once, from a Java-originating thread.

## Root cause

`SyncEngine::scheduleRetryLocked` spawns retries on bare `std::thread`s. When `httpRequest` runs on one of those threads, `getEnv()` attaches it via `AttachCurrentThread`, and `env->FindClass("com/nozbe/watermelondb/sync/SyncHttpManager")` then resolves against the system class loader — which can't see app classes — and returns `null`. `callStartRequest` returns `false`, surfacing as `"Failed to start HTTP request"`.

The first sync attempt always succeeds because it originates from the JS bridge thread (which descends from a Java caller and has the app class loader). But every retry after a transient network failure runs on a fresh native thread, the lookup fails, and because each failure schedules another retry, the failure mode is self-reinforcing — log spam until the engine gives up.

Reference: https://developer.android.com/training/articles/perf-jni#faq:-why-didnt-findclass-find-my-class

## Fix

Resolve the class once and cache it as a global ref. The first call from the JS bridge thread (initial sync) primes the cache; retries on bare `std::thread`s reuse the cached ref and skip `FindClass` entirely. `compare_exchange_strong` handles the unlikely race where two threads prime concurrently.

The `cls` ref is now permanent for the process lifetime, so the matching `DeleteGlobalRef(cls)` in `callStartRequest` is removed.

`generateRequestId` is unchanged — it only looks up `java/util/UUID`, which is a system class and resolves on any thread.

## Note on versioning

This change was published as `7.0.4-8` on npm (the publish ran with the cpp diff in the working tree before this PR was opened), but the `v7.0.4-8` tag on `main` only contains the version bump. Merging this PR aligns the git history with what's already published.

## Test plan

- [ ] Install `@BuildHero/watermelondb@7.0.4-8` in `buildhero-mobile`, build Android, verify sync retries succeed after a network blip (toggle airplane mode mid-sync).
- [ ] Confirm `Failed to start HTTP request` no longer appears in production logs after rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)