### PR TITLE
debug(ios): attribute writer-lock holder + log BUSY context

### DIFF
--- a/native/ios/WatermelonDB/Database.swift
+++ b/native/ios/WatermelonDB/Database.swift
@@ -1,6 +1,34 @@
 import Foundation
 import SQLite3
 
+/// Runtime gate for writer-lock diagnostic logging. Default `true` in DEBUG,
+/// `false` in release. Toggleable from native code via `WMDBLockLog.isEnabled`
+/// (Obj-C: `WMDBLockLog.isEnabled = YES`). When disabled, all `[wmdb-lock]`
+/// log sites short-circuit at the call site before any string formatting.
+@objc(WMDBLockLog)
+public final class WMDBLockLog: NSObject {
+    private static var _enabled: Bool = {
+        #if DEBUG
+        return true
+        #else
+        return false
+        #endif
+    }()
+
+    @objc
+    public class var isEnabled: Bool {
+        get { return _enabled }
+        set { _enabled = newValue }
+    }
+}
+
+@inline(__always)
+internal func wmdbLockLog(_ message: @autoclosure () -> String) {
+    if WMDBLockLog.isEnabled {
+        consoleLog(message())
+    }
+}
+
 public class Database {
     public typealias SQL = String
     public typealias TableName = String
@@ -45,7 +73,7 @@ public class Database {
         _currentHolder = name
         _holderAcquiredAt = Date()
         holderLock.unlock()
-        consoleLog("[wmdb-lock] holder=\(name) acquired (prev=\(prev))")
+        wmdbLockLog("[wmdb-lock] holder=\(name) acquired (prev=\(prev))")
     }
 
     public func clearWriterHolder() {
@@ -55,7 +83,7 @@ public class Database {
         _currentHolder = "(none)"
         _holderAcquiredAt = nil
         holderLock.unlock()
-        consoleLog(String(format: "[wmdb-lock] holder=%@ released (held %.0fms)", name, durationMs))
+        wmdbLockLog(String(format: "[wmdb-lock] holder=%@ released (held %.0fms)", name, durationMs))
     }
 
     public func currentHolderInfo() -> String {
@@ -123,12 +151,16 @@ public class Database {
     }
     
     func inTransaction(_ executeBlock: () throws -> Void) throws {
-        let holderBeforeWait = currentHolderInfo()
-        let waitStart = Date()
+        // Skip wait-time accounting entirely when diagnostics are off.
+        let diagnosticsOn = WMDBLockLog.isEnabled
+        let holderBeforeWait = diagnosticsOn ? currentHolderInfo() : ""
+        let waitStart = diagnosticsOn ? Date() : nil
         writerTransactionSemaphore.wait()
-        let waitMs = Date().timeIntervalSince(waitStart) * 1000
-        if waitMs > 50 {
-            consoleLog(String(format: "[wmdb-lock] js-action waited %.0fms for sem (prev holder: %@)", waitMs, holderBeforeWait))
+        if let waitStart = waitStart {
+            let waitMs = Date().timeIntervalSince(waitStart) * 1000
+            if waitMs > 50 {
+                wmdbLockLog(String(format: "[wmdb-lock] js-action waited %.0fms for sem (prev holder: %@)", waitMs, holderBeforeWait))
+            }
         }
         setWriterHolder("js-action")
         defer {
@@ -139,7 +171,7 @@ public class Database {
         guard writer.beginTransaction() else {
             let err = writer.lastError()
             if isBusyError(err.localizedDescription) {
-                consoleLog("[wmdb-lock] js-action BEGIN BUSY error=\(err.localizedDescription) holder=\(currentHolderInfo())")
+                wmdbLockLog("[wmdb-lock] js-action BEGIN BUSY error=\(err.localizedDescription) holder=\(currentHolderInfo())")
             }
             throw err
         }
@@ -177,9 +209,9 @@ public class Database {
             try writer.executeUpdate(query, values: args)
         } catch {
             let nsErr = error as NSError
-            if isBusyError(nsErr.localizedDescription) {
+            if WMDBLockLog.isEnabled && isBusyError(nsErr.localizedDescription) {
                 let truncatedQuery = query.count > 80 ? String(query.prefix(80)) + "…" : query
-                consoleLog("[wmdb-lock] execute BUSY error=\(nsErr.localizedDescription) query=\"\(truncatedQuery)\" holder=\(currentHolderInfo())")
+                wmdbLockLog("[wmdb-lock] execute BUSY error=\(nsErr.localizedDescription) query=\"\(truncatedQuery)\" holder=\(currentHolderInfo())")
             }
             throw error
         }
@@ -189,9 +221,9 @@ public class Database {
     func executeStatements(_ queries: SQL) throws {
         guard writer.executeStatements(queries) else {
             let err = writer.lastError()
-            if isBusyError(err.localizedDescription) {
+            if WMDBLockLog.isEnabled && isBusyError(err.localizedDescription) {
                 let truncated = queries.count > 80 ? String(queries.prefix(80)) + "…" : queries
-                consoleLog("[wmdb-lock] executeStatements BUSY error=\(err.localizedDescription) queries=\"\(truncated)\" holder=\(currentHolderInfo())")
+                wmdbLockLog("[wmdb-lock] executeStatements BUSY error=\(err.localizedDescription) queries=\"\(truncated)\" holder=\(currentHolderInfo())")
             }
             throw err
         }

--- a/native/ios/WatermelonDB/Database.swift
+++ b/native/ios/WatermelonDB/Database.swift
@@ -30,6 +30,49 @@ public class Database {
     /// and SliceImport. Acquired before BEGIN, released after COMMIT/ROLLBACK.
     public let writerTransactionSemaphore = DispatchSemaphore(value: 1)
 
+    // MARK: - Writer-lock holder tracking (diagnostics)
+    // Tracks who currently holds the writer (or has it BEGIN IMMEDIATE'd) so
+    // that BUSY errors on the non-transactional writer path can attribute the
+    // collision. Acquirers (Database.inTransaction, slice import, sync apply)
+    // set this on acquire and clear on release.
+    private let holderLock = NSLock()
+    private var _currentHolder: String = "(none)"
+    private var _holderAcquiredAt: Date?
+
+    public func setWriterHolder(_ name: String) {
+        holderLock.lock()
+        let prev = _currentHolder
+        _currentHolder = name
+        _holderAcquiredAt = Date()
+        holderLock.unlock()
+        consoleLog("[wmdb-lock] holder=\(name) acquired (prev=\(prev))")
+    }
+
+    public func clearWriterHolder() {
+        holderLock.lock()
+        let name = _currentHolder
+        let durationMs = _holderAcquiredAt.map { Date().timeIntervalSince($0) * 1000 } ?? 0
+        _currentHolder = "(none)"
+        _holderAcquiredAt = nil
+        holderLock.unlock()
+        consoleLog(String(format: "[wmdb-lock] holder=%@ released (held %.0fms)", name, durationMs))
+    }
+
+    public func currentHolderInfo() -> String {
+        holderLock.lock()
+        defer { holderLock.unlock() }
+        if let acquiredAt = _holderAcquiredAt {
+            let elapsed = Date().timeIntervalSince(acquiredAt) * 1000
+            return String(format: "%@ (held %.0fms)", _currentHolder, elapsed)
+        }
+        return _currentHolder
+    }
+
+    private func isBusyError(_ message: String) -> Bool {
+        let lower = message.lowercased()
+        return lower.contains("locked") || lower.contains("busy")
+    }
+
     init(path: String) {
         self.path = path
         writer = FMDatabase(path: path)
@@ -80,10 +123,26 @@ public class Database {
     }
     
     func inTransaction(_ executeBlock: () throws -> Void) throws {
+        let holderBeforeWait = currentHolderInfo()
+        let waitStart = Date()
         writerTransactionSemaphore.wait()
-        defer { writerTransactionSemaphore.signal() }
+        let waitMs = Date().timeIntervalSince(waitStart) * 1000
+        if waitMs > 50 {
+            consoleLog(String(format: "[wmdb-lock] js-action waited %.0fms for sem (prev holder: %@)", waitMs, holderBeforeWait))
+        }
+        setWriterHolder("js-action")
+        defer {
+            clearWriterHolder()
+            writerTransactionSemaphore.signal()
+        }
 
-        guard writer.beginTransaction() else { throw writer.lastError() }
+        guard writer.beginTransaction() else {
+            let err = writer.lastError()
+            if isBusyError(err.localizedDescription) {
+                consoleLog("[wmdb-lock] js-action BEGIN BUSY error=\(err.localizedDescription) holder=\(currentHolderInfo())")
+            }
+            throw err
+        }
 
         // Atomically increment transaction depth
         transactionLock.lock()
@@ -112,15 +171,29 @@ public class Database {
             throw error
         }
     }
-    
+
     func execute(_ query: SQL, _ args: QueryArgs = []) throws {
-        try writer.executeUpdate(query, values: args)
+        do {
+            try writer.executeUpdate(query, values: args)
+        } catch {
+            let nsErr = error as NSError
+            if isBusyError(nsErr.localizedDescription) {
+                let truncatedQuery = query.count > 80 ? String(query.prefix(80)) + "…" : query
+                consoleLog("[wmdb-lock] execute BUSY error=\(nsErr.localizedDescription) query=\"\(truncatedQuery)\" holder=\(currentHolderInfo())")
+            }
+            throw error
+        }
     }
-    
+
     /// Executes multiple queries separated by `;`
     func executeStatements(_ queries: SQL) throws {
         guard writer.executeStatements(queries) else {
-            throw writer.lastError()
+            let err = writer.lastError()
+            if isBusyError(err.localizedDescription) {
+                let truncated = queries.count > 80 ? String(queries.prefix(80)) + "…" : queries
+                consoleLog("[wmdb-lock] executeStatements BUSY error=\(err.localizedDescription) queries=\"\(truncated)\" holder=\(currentHolderInfo())")
+            }
+            throw err
         }
     }
     

--- a/native/ios/WatermelonDB/DatabaseBridge.swift
+++ b/native/ios/WatermelonDB/DatabaseBridge.swift
@@ -93,6 +93,38 @@ final public class DatabaseBridge: RCTEventEmitter {
         return driver.database.writerTransactionSemaphore
     }
 
+    // MARK: - Writer-lock holder accessors (diagnostics)
+    // Used by SliceImportDatabaseAdapter and JSISwiftWrapperModule to attribute
+    // who holds the writer at any given moment, so BUSY errors on the
+    // non-transactional writer path can name the colliding party.
+
+    @objc
+    public func setWriterHolder(connectionTag: ConnectionTag, name: String) {
+        guard let connection = connections[connectionTag.intValue],
+              case let .connected(driver, synchronous: true) = connection else {
+            return
+        }
+        driver.database.setWriterHolder(name)
+    }
+
+    @objc
+    public func clearWriterHolder(connectionTag: ConnectionTag) {
+        guard let connection = connections[connectionTag.intValue],
+              case let .connected(driver, synchronous: true) = connection else {
+            return
+        }
+        driver.database.clearWriterHolder()
+    }
+
+    @objc
+    public func currentWriterHolder(connectionTag: ConnectionTag) -> String {
+        guard let connection = connections[connectionTag.intValue],
+              case let .connected(driver, synchronous: true) = connection else {
+            return "(no-connection)"
+        }
+        return driver.database.currentHolderInfo()
+    }
+
     @objc
     public func isCached(connectionTag: ConnectionTag, table: String, id: String) -> Bool {
         guard let connection = connections[connectionTag.intValue], case let .connected(driver, synchronous: true) = connection else {

--- a/native/ios/WatermelonDB/JSISwiftWrapper/JSISwiftWrapperModule.mm
+++ b/native/ios/WatermelonDB/JSISwiftWrapper/JSISwiftWrapperModule.mm
@@ -17,6 +17,14 @@
 
 #include <exception>
 
+// Gated lock-diagnostic logging — controlled at runtime by `WMDBLockLog.isEnabled`
+// (defaults: ON in DEBUG, OFF in release).
+#define WMDB_LOCK_LOG(fmt, ...) do { \
+    if (WMDBLockLog.isEnabled) { \
+        NSLog(fmt, ##__VA_ARGS__); \
+    } \
+} while (0)
+
 namespace facebook::react {
 
 static NSMutableSet<SliceImporter *> *activeSliceImporters() {
@@ -68,13 +76,16 @@ JSISwiftWrapperModule::JSISwiftWrapperModule(std::shared_ptr<CallInvoker> jsInvo
                 errorMessage = "Could not get writer transaction semaphore";
                 return false;
             }
-            NSString *prevHolder = [db currentWriterHolderWithConnectionTag:tagNumber];
-            NSTimeInterval waitStart = [NSDate timeIntervalSinceReferenceDate];
+            BOOL diagOn = WMDBLockLog.isEnabled;
+            NSString *prevHolder = diagOn ? [db currentWriterHolderWithConnectionTag:tagNumber] : nil;
+            NSTimeInterval waitStart = diagOn ? [NSDate timeIntervalSinceReferenceDate] : 0;
             dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
-            double waitMs = ([NSDate timeIntervalSinceReferenceDate] - waitStart) * 1000.0;
-            if (waitMs > 50.0) {
-                NSLog(@"[wmdb-lock] native-sync:apply waited %.0fms for sem (prev holder: %@)",
-                      waitMs, prevHolder);
+            if (diagOn) {
+                double waitMs = ([NSDate timeIntervalSinceReferenceDate] - waitStart) * 1000.0;
+                if (waitMs > 50.0) {
+                    WMDB_LOCK_LOG(@"[wmdb-lock] native-sync:apply waited %.0fms for sem (prev holder: %@)",
+                                  waitMs, prevHolder);
+                }
             }
             [db setWriterHolderWithConnectionTag:tagNumber name:@"native-sync:apply"];
 
@@ -85,14 +96,16 @@ JSISwiftWrapperModule::JSISwiftWrapperModule(std::shared_ptr<CallInvoker> jsInvo
                 errorMessage = "Failed to get SQLite connection";
                 return false;
             }
-            NSTimeInterval applyStart = [NSDate timeIntervalSinceReferenceDate];
+            NSTimeInterval applyStart = diagOn ? [NSDate timeIntervalSinceReferenceDate] : 0;
             bool result = watermelondb::applySyncPayload(sqlite, payload, errorMessage);
-            double applyMs = ([NSDate timeIntervalSinceReferenceDate] - applyStart) * 1000.0;
-            if (!result) {
-                NSLog(@"[wmdb-lock] native-sync:apply FAILED after %.0fms: %s",
-                      applyMs, errorMessage.c_str());
-            } else if (applyMs > 250.0) {
-                NSLog(@"[wmdb-lock] native-sync:apply ok (took %.0fms)", applyMs);
+            if (diagOn) {
+                double applyMs = ([NSDate timeIntervalSinceReferenceDate] - applyStart) * 1000.0;
+                if (!result) {
+                    WMDB_LOCK_LOG(@"[wmdb-lock] native-sync:apply FAILED after %.0fms: %s",
+                                  applyMs, errorMessage.c_str());
+                } else if (applyMs > 250.0) {
+                    WMDB_LOCK_LOG(@"[wmdb-lock] native-sync:apply ok (took %.0fms)", applyMs);
+                }
             }
 
             [db clearWriterHolderWithConnectionTag:tagNumber];

--- a/native/ios/WatermelonDB/JSISwiftWrapper/JSISwiftWrapperModule.mm
+++ b/native/ios/WatermelonDB/JSISwiftWrapper/JSISwiftWrapperModule.mm
@@ -68,16 +68,34 @@ JSISwiftWrapperModule::JSISwiftWrapperModule(std::shared_ptr<CallInvoker> jsInvo
                 errorMessage = "Could not get writer transaction semaphore";
                 return false;
             }
+            NSString *prevHolder = [db currentWriterHolderWithConnectionTag:tagNumber];
+            NSTimeInterval waitStart = [NSDate timeIntervalSinceReferenceDate];
             dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
+            double waitMs = ([NSDate timeIntervalSinceReferenceDate] - waitStart) * 1000.0;
+            if (waitMs > 50.0) {
+                NSLog(@"[wmdb-lock] native-sync:apply waited %.0fms for sem (prev holder: %@)",
+                      waitMs, prevHolder);
+            }
+            [db setWriterHolderWithConnectionTag:tagNumber name:@"native-sync:apply"];
 
             sqlite3 *sqlite = (sqlite3 *)[db getRawConnectionWithConnectionTag:tagNumber];
             if (!sqlite) {
+                [db clearWriterHolderWithConnectionTag:tagNumber];
                 dispatch_semaphore_signal(sem);
                 errorMessage = "Failed to get SQLite connection";
                 return false;
             }
+            NSTimeInterval applyStart = [NSDate timeIntervalSinceReferenceDate];
             bool result = watermelondb::applySyncPayload(sqlite, payload, errorMessage);
+            double applyMs = ([NSDate timeIntervalSinceReferenceDate] - applyStart) * 1000.0;
+            if (!result) {
+                NSLog(@"[wmdb-lock] native-sync:apply FAILED after %.0fms: %s",
+                      applyMs, errorMessage.c_str());
+            } else if (applyMs > 250.0) {
+                NSLog(@"[wmdb-lock] native-sync:apply ok (took %.0fms)", applyMs);
+            }
 
+            [db clearWriterHolderWithConnectionTag:tagNumber];
             dispatch_semaphore_signal(sem);
             return result;
         }

--- a/native/ios/WatermelonDB/SliceImportDatabaseAdapter.mm
+++ b/native/ios/WatermelonDB/SliceImportDatabaseAdapter.mm
@@ -19,6 +19,15 @@
 using watermelondb::DatabaseInterface;
 using watermelondb::FieldValue;
 
+// Gated lock-diagnostic logging — controlled at runtime by `WMDBLockLog.isEnabled`
+// (defaults: ON in DEBUG, OFF in release). When disabled, the macro evaluates
+// to a single static getter call and skips argument formatting entirely.
+#define WMDB_LOCK_LOG(fmt, ...) do { \
+    if (WMDBLockLog.isEnabled) { \
+        NSLog(fmt, ##__VA_ARGS__); \
+    } \
+} while (0)
+
 namespace {
 static void *kDBQueueKey = &kDBQueueKey;
 static std::atomic<uint64_t> sliceImportSeq{0};
@@ -87,13 +96,16 @@ public:
             errorMessage = "Could not get writer transaction semaphore";
             return false;
         }
-        NSString *prevHolder = [db_ currentWriterHolderWithConnectionTag:connectionTag_];
-        NSTimeInterval waitStart = [NSDate timeIntervalSinceReferenceDate];
+        BOOL diagOn = WMDBLockLog.isEnabled;
+        NSString *prevHolder = diagOn ? [db_ currentWriterHolderWithConnectionTag:connectionTag_] : nil;
+        NSTimeInterval waitStart = diagOn ? [NSDate timeIntervalSinceReferenceDate] : 0;
         dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
-        double waitMs = ([NSDate timeIntervalSinceReferenceDate] - waitStart) * 1000.0;
-        if (waitMs > 50.0) {
-            NSLog(@"[wmdb-lock] %s waited %.0fms for sem (prev holder: %@)",
-                  holderName_.c_str(), waitMs, prevHolder);
+        if (diagOn) {
+            double waitMs = ([NSDate timeIntervalSinceReferenceDate] - waitStart) * 1000.0;
+            if (waitMs > 50.0) {
+                WMDB_LOCK_LOG(@"[wmdb-lock] %s waited %.0fms for sem (prev holder: %@)",
+                              holderName_.c_str(), waitMs, prevHolder);
+            }
         }
         writerSemaphore_ = sem;
         [db_ setWriterHolderWithConnectionTag:connectionTag_
@@ -117,11 +129,11 @@ public:
         execSQL(db, "PRAGMA temp_store=MEMORY;", ignored);
         execSQL(db, "PRAGMA cache_size=-20000;", ignored);
         execSQL(db, "PRAGMA wal_autocheckpoint=10000;", ignored);
-        txnStartAbsTime_ = [NSDate timeIntervalSinceReferenceDate];
+        txnStartAbsTime_ = WMDBLockLog.isEnabled ? [NSDate timeIntervalSinceReferenceDate] : 0.0;
         if (!execSQL(db, "BEGIN IMMEDIATE;", errorMessage)) {
-            NSLog(@"[wmdb-lock] %s BEGIN IMMEDIATE failed: %s (holder reported: %@)",
-                  holderName_.c_str(), errorMessage.c_str(),
-                  [db_ currentWriterHolderWithConnectionTag:connectionTag_]);
+            WMDB_LOCK_LOG(@"[wmdb-lock] %s BEGIN IMMEDIATE failed: %s (holder reported: %@)",
+                          holderName_.c_str(), errorMessage.c_str(),
+                          [db_ currentWriterHolderWithConnectionTag:connectionTag_]);
             [db_ clearWriterHolderWithConnectionTag:connectionTag_];
             dispatch_semaphore_signal(writerSemaphore_);
             writerSemaphore_ = nil;
@@ -143,13 +155,15 @@ public:
             return false;
         }
         if (!execSQL(db, "COMMIT;", errorMessage)) {
-            NSLog(@"[wmdb-lock] %s COMMIT failed: %s", holderName_.c_str(), errorMessage.c_str());
+            WMDB_LOCK_LOG(@"[wmdb-lock] %s COMMIT failed: %s", holderName_.c_str(), errorMessage.c_str());
             rollbackTransactionOnDB(db);
             return false;
         }
         transactionStarted_ = false;
-        double heldMs = ([NSDate timeIntervalSinceReferenceDate] - txnStartAbsTime_) * 1000.0;
-        NSLog(@"[wmdb-lock] %s COMMIT ok (txn held %.0fms)", holderName_.c_str(), heldMs);
+        if (WMDBLockLog.isEnabled) {
+            double heldMs = ([NSDate timeIntervalSinceReferenceDate] - txnStartAbsTime_) * 1000.0;
+            WMDB_LOCK_LOG(@"[wmdb-lock] %s COMMIT ok (txn held %.0fms)", holderName_.c_str(), heldMs);
+        }
 
         // WAL checkpoint for predictable completion
         int logFrames = 0;
@@ -175,8 +189,10 @@ public:
     void rollbackTransaction() override {
         sqlite3 *db = cachedDB_;
         if (db) {
-            double heldMs = ([NSDate timeIntervalSinceReferenceDate] - txnStartAbsTime_) * 1000.0;
-            NSLog(@"[wmdb-lock] %s ROLLBACK (txn held %.0fms)", holderName_.c_str(), heldMs);
+            if (WMDBLockLog.isEnabled) {
+                double heldMs = ([NSDate timeIntervalSinceReferenceDate] - txnStartAbsTime_) * 1000.0;
+                WMDB_LOCK_LOG(@"[wmdb-lock] %s ROLLBACK (txn held %.0fms)", holderName_.c_str(), heldMs);
+            }
             rollbackTransactionOnDB(db);
         }
         cachedDB_ = nullptr;

--- a/native/ios/WatermelonDB/SliceImportDatabaseAdapter.mm
+++ b/native/ios/WatermelonDB/SliceImportDatabaseAdapter.mm
@@ -14,12 +14,14 @@
 #endif
 
 #include <string>
+#include <atomic>
 
 using watermelondb::DatabaseInterface;
 using watermelondb::FieldValue;
 
 namespace {
 static void *kDBQueueKey = &kDBQueueKey;
+static std::atomic<uint64_t> sliceImportSeq{0};
 
 static bool execSQL(sqlite3 *db, const char *sql, std::string &errorMessage) {
     char *errMsg = nullptr;
@@ -45,7 +47,9 @@ public:
         , methodQueue_(db ? db.methodQueue : nullptr)
         , transactionStarted_(false)
         , writerSemaphore_(nil)
-        , cachedDB_(nullptr) {
+        , cachedDB_(nullptr)
+        , holderName_("")
+        , txnStartAbsTime_(0.0) {
         if (methodQueue_) {
             dispatch_queue_set_specific(methodQueue_, kDBQueueKey, kDBQueueKey, nullptr);
         }
@@ -70,18 +74,35 @@ public:
             return false;
         }
 
+        // Build a unique holder tag so we can attribute BUSY collisions.
+        uint64_t seq = ++sliceImportSeq;
+        char holderBuf[64];
+        snprintf(holderBuf, sizeof(holderBuf), "slice-import:%lld:#%llu",
+                 (long long)[connectionTag_ longLongValue], (unsigned long long)seq);
+        holderName_ = holderBuf;
+
         // Acquire the writer transaction semaphore — blocks until JS writes finish
         dispatch_semaphore_t sem = [db_ getWriterTransactionSemaphoreWithConnectionTag:connectionTag_];
         if (!sem) {
             errorMessage = "Could not get writer transaction semaphore";
             return false;
         }
+        NSString *prevHolder = [db_ currentWriterHolderWithConnectionTag:connectionTag_];
+        NSTimeInterval waitStart = [NSDate timeIntervalSinceReferenceDate];
         dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
+        double waitMs = ([NSDate timeIntervalSinceReferenceDate] - waitStart) * 1000.0;
+        if (waitMs > 50.0) {
+            NSLog(@"[wmdb-lock] %s waited %.0fms for sem (prev holder: %@)",
+                  holderName_.c_str(), waitMs, prevHolder);
+        }
         writerSemaphore_ = sem;
+        [db_ setWriterHolderWithConnectionTag:connectionTag_
+                                         name:[NSString stringWithUTF8String:holderName_.c_str()]];
 
         // Get raw sqlite3* directly (bypasses methodQueue — semaphore provides serialization)
         sqlite3 *db = (sqlite3 *)[db_ getRawConnectionWithConnectionTag:connectionTag_];
         if (!db) {
+            [db_ clearWriterHolderWithConnectionTag:connectionTag_];
             dispatch_semaphore_signal(writerSemaphore_);
             writerSemaphore_ = nil;
             errorMessage = "Lost database connection";
@@ -96,7 +117,12 @@ public:
         execSQL(db, "PRAGMA temp_store=MEMORY;", ignored);
         execSQL(db, "PRAGMA cache_size=-20000;", ignored);
         execSQL(db, "PRAGMA wal_autocheckpoint=10000;", ignored);
+        txnStartAbsTime_ = [NSDate timeIntervalSinceReferenceDate];
         if (!execSQL(db, "BEGIN IMMEDIATE;", errorMessage)) {
+            NSLog(@"[wmdb-lock] %s BEGIN IMMEDIATE failed: %s (holder reported: %@)",
+                  holderName_.c_str(), errorMessage.c_str(),
+                  [db_ currentWriterHolderWithConnectionTag:connectionTag_]);
+            [db_ clearWriterHolderWithConnectionTag:connectionTag_];
             dispatch_semaphore_signal(writerSemaphore_);
             writerSemaphore_ = nil;
             cachedDB_ = nullptr;
@@ -117,10 +143,13 @@ public:
             return false;
         }
         if (!execSQL(db, "COMMIT;", errorMessage)) {
+            NSLog(@"[wmdb-lock] %s COMMIT failed: %s", holderName_.c_str(), errorMessage.c_str());
             rollbackTransactionOnDB(db);
             return false;
         }
         transactionStarted_ = false;
+        double heldMs = ([NSDate timeIntervalSinceReferenceDate] - txnStartAbsTime_) * 1000.0;
+        NSLog(@"[wmdb-lock] %s COMMIT ok (txn held %.0fms)", holderName_.c_str(), heldMs);
 
         // WAL checkpoint for predictable completion
         int logFrames = 0;
@@ -134,6 +163,7 @@ public:
         execSQL(db, "PRAGMA wal_autocheckpoint=1000;", ignored);
 
         cachedDB_ = nullptr;
+        [db_ clearWriterHolderWithConnectionTag:connectionTag_];
         if (writerSemaphore_) {
             dispatch_semaphore_signal(writerSemaphore_);
             writerSemaphore_ = nil;
@@ -145,9 +175,12 @@ public:
     void rollbackTransaction() override {
         sqlite3 *db = cachedDB_;
         if (db) {
+            double heldMs = ([NSDate timeIntervalSinceReferenceDate] - txnStartAbsTime_) * 1000.0;
+            NSLog(@"[wmdb-lock] %s ROLLBACK (txn held %.0fms)", holderName_.c_str(), heldMs);
             rollbackTransactionOnDB(db);
         }
         cachedDB_ = nullptr;
+        [db_ clearWriterHolderWithConnectionTag:connectionTag_];
         if (writerSemaphore_) {
             dispatch_semaphore_signal(writerSemaphore_);
             writerSemaphore_ = nil;
@@ -204,6 +237,8 @@ private:
     bool transactionStarted_;
     dispatch_semaphore_t writerSemaphore_;
     sqlite3 *cachedDB_;
+    std::string holderName_;
+    NSTimeInterval txnStartAbsTime_;
 
     void finalizeStatements() {
         if (cachedDB_) {


### PR DESCRIPTION
## Summary

Diagnostic logging to identify which native code path holds the SQLite writer when "database is locked" errors surface in the buildhero-mobile app. **No behavior change** outside of `NSLog` output.

## Why

In buildhero-mobile we're seeing recurring `Error Domain=FMDatabase Code=5 "database is locked"` failures during boot + sync. The shared `writerTransactionSemaphore` is acquired by three paths:

1. `Database.inTransaction` — JS-side `database.action()` writes
2. `SliceImportDatabaseAdapter::beginTransaction` — slice imports
3. `JSISwiftWrapperModule` sync-apply callback — native sync engine

…but nothing names the current holder. JS-side writes (`setLocal`, `executeStatements`, `execSqlQueryOnWriter`) go through `Database.execute` which does **not** acquire the semaphore — so when they BUSY, we have no way to attribute the collision to a specific party (slice import? sync apply? prior JS action?).

This PR adds a `[wmdb-lock]`-tagged log surface that names the current holder on every acquire/release and quotes that holder in BUSY error logs.

## Changes

- **`Database.swift`** — Track current writer holder under `holderLock`; expose `setWriterHolder`/`clearWriterHolder`/`currentHolderInfo`. `inTransaction` logs sem wait > 50ms and sets holder to `js-action`. `execute`/`executeStatements` log holder context on any BUSY/locked error.
- **`DatabaseBridge.swift`** — Expose `setWriterHolderWithConnectionTag:name:`, `clearWriterHolderWithConnectionTag:`, `currentWriterHolderWithConnectionTag:` for Obj-C/C++ callers.
- **`SliceImportDatabaseAdapter.mm`** — Assigns unique holder tag `slice-import:<connTag>:#<seq>`. Logs sem wait time, BEGIN IMMEDIATE failure with reported holder, txn hold duration on commit/rollback.
- **`JSISwiftWrapperModule.mm`** — Sync-engine apply callback sets holder to `native-sync:apply`. Logs sem wait, apply duration, apply failure.

## Expected log output

Grep `[wmdb-lock]` in the Xcode console:

```
[wmdb-lock] holder=slice-import:1:#1 acquired (prev=(none))
[wmdb-lock] holder=slice-import:1:#1 released (held 4123ms)
[wmdb-lock] execute BUSY error=… query="insert or replace into local_storage…" holder=slice-import:1:#2 (held 4321ms)
[wmdb-lock] js-action waited 3200ms for sem (prev holder: native-sync:apply (held 3200ms))
[wmdb-lock] native-sync:apply FAILED after 187ms: database is locked
```

The first BUSY line is the one that closes the diagnostic gap — it names the collider.

## Test plan

- [ ] Build the fork (`yarn build` from root).
- [ ] Publish as a prerelease tag.
- [ ] Point buildhero-mobile at the prerelease version (3 `package.json` files).
- [ ] Run iOS dev build; trigger the sync-on-boot path that's been reproducing BUSY.
- [ ] Grep Xcode console for `[wmdb-lock]` — confirm the lines name the collider on every BUSY.
- [ ] Drop log volume (or gate behind a debug flag) before merging to `main`.

## Notes

- All `[wmdb-lock]` logs use `NSLog`/`consoleLog` (existing primitive). Volume is bounded: one acquire + one release per writer transaction, plus BUSY-only lines.
- `currentHolderInfo()` reports the elapsed hold time so the BUSY log shows how long the collider has been holding.
- Pre-PR diagnostic only — this should not be merged to `main` without being gated or stripped after we've nailed down the root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)