### PR TITLE
perf(android): respect reactNativeArchitectures for CMake abiFilters - MOBILE-5519

### DIFF
--- a/native/android/build.gradle
+++ b/native/android/build.gradle
@@ -8,6 +8,11 @@ def DEFAULT_TARGET_SDK_VERSION = 33
 
 def newArchEnabled = project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
 
+def reactNativeArchitectures() {
+    def value = project.getProperties().get("reactNativeArchitectures")
+    return value ? value.split(",") : ["armeabi-v7a", "arm64-v8a", "x86", "x86_64"]
+}
+
 android {
     namespace "com.nozbe.watermelondb"
 
@@ -22,6 +27,7 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {
+                abiFilters (*reactNativeArchitectures())
                 arguments "-DANDROID_STL=c++_shared", "-DREACT_NATIVE_NEW_ARCH_ENABLED=${newArchEnabled ? 1 : 0}"
                 cppFlags '-std=c++17 -O2'
             }


### PR DESCRIPTION
## Summary

Builds only the ABIs Gradle is asked for. When `expo run:android` (or any RN consumer) passes `-PreactNativeArchitectures=arm64-v8a`, CMake compiles the single requested ABI instead of all four. Falls back to all four ABIs when the property is unset, preserving today's CI behavior.

This replaces a patch-package patch currently carried downstream in [buildhero-mobile](https://github.com/BuildHero/buildhero-mobile) at `patches/@BuildHero+watermelondb+7.0.4-9.patch`. Owning the change in source removes the patch-rebase risk we hit on every fork update and makes the dev-build optimization available to anyone consuming the fork.

## Why this lives here, not in patch-package

- patch-package patches break silently when context lines shift on a fork rebase.
- This is a 6-line change to a file we already own — there's no reason for it to live as a downstream patch.
- Required for [MOBILE-5519](https://buildops.atlassian.net/browse/MOBILE-5519) (Android dev productivity), which depends on the single-ABI build to cut a warm rebuild from 12 min → 13 s.

## Impact

| Caller | Before | After |
|---|---|---|
| `expo run:android` (single-device) | builds 4 ABIs (~75 s wasted) | builds 1 ABI |
| CI (no `-PreactNativeArchitectures` set) | builds 4 ABIs | builds 4 ABIs (unchanged) |
| Manual `./gradlew` with `-PreactNativeArchitectures=arm64-v8a,x86_64` | unsupported | builds only the listed ABIs |

## Test plan

- [x] Diff matches the existing patch-package patch byte-for-byte (verified via `git diff` vs `patches/@BuildHero+watermelondb+7.0.4-9.patch`)
- [ ] After merge + new version published (likely `v7.0.4-10`): bump `@BuildHero/watermelondb` in `buildhero-mobile/packages/mobile/package.json`, delete the patch, verify Android warm rebuild stays in the ~13 s range with single-ABI build

## Follow-ups (not in this PR)

- Publish a new fork version after merge so [MOBILE-5519](https://buildops.atlassian.net/browse/MOBILE-5519) PR [#5878](https://github.com/BuildHero/buildhero-mobile/pull/5878) can drop the patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MOBILE-5519]: https://buildops.atlassian.net/browse/MOBILE-5519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOBILE-5519]: https://buildops.atlassian.net/browse/MOBILE-5519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ