### PR TITLE
fix(ios): serialize standalone writes against the writer semaphore - MOBILE-5606

### DIFF
--- a/native/ios/WatermelonDB/Database.swift
+++ b/native/ios/WatermelonDB/Database.swift
@@ -228,7 +228,36 @@ public class Database {
             throw err
         }
     }
-    
+
+    /// Serialized single-statement writer entry point. Acquires
+    /// `writerTransactionSemaphore` WITHOUT opening a transaction, so callers
+    /// that cannot run inside a txn (ATTACH/DETACH/VACUUM) are still serialized
+    /// against in-flight `inTransaction` / slice-import writes on the shared
+    /// writer connection (MOBILE-5606). MUST NOT be called from inside
+    /// `inTransaction` — `writerTransactionSemaphore` is non-reentrant.
+    func executeStandalone(_ query: SQL, _ args: QueryArgs = []) throws {
+        writerTransactionSemaphore.wait()
+        setWriterHolder("standalone")
+        defer {
+            clearWriterHolder()
+            writerTransactionSemaphore.signal()
+        }
+        try execute(query, args)
+    }
+
+    /// Serialized multi-statement variant of `executeStandalone`. Same
+    /// preconditions: acquires the semaphore, opens no transaction, and MUST
+    /// NOT be called while the semaphore is already held.
+    func executeStatementsStandalone(_ queries: SQL) throws {
+        writerTransactionSemaphore.wait()
+        setWriterHolder("standalone")
+        defer {
+            clearWriterHolder()
+            writerTransactionSemaphore.signal()
+        }
+        try executeStatements(queries)
+    }
+
     func getRawPointer() -> OpaquePointer {
         return OpaquePointer(writer.sqliteHandle)
     }
@@ -319,12 +348,30 @@ public class Database {
             return result.long(forColumnIndex: 0)
         }
         set {
+            // PRECONDITION: caller must hold `writerTransactionSemaphore` (i.e.
+            // run inside `inTransaction`). Uses bare `execute`; do NOT make it
+            // self-acquire — setUpSchema/migrate set this from inside
+            // `inTransaction`, so acquiring here would deadlock (MOBILE-5606).
             // swiftlint:disable:next force_try
             try! execute("pragma user_version = \(newValue)")
         }
     }
     
     func unsafeDestroyEverything() throws {
+        // MOBILE-5606: hold the writer semaphore across the entire teardown so a
+        // reset/logout (unsafeResetDatabase) cannot vacuum, close the connection,
+        // or delete DB files while an `inTransaction` / slice-import write is in
+        // flight on the shared writer connection. wait() blocks until any
+        // in-flight transaction releases. Inner writes stay BARE
+        // (execute/executeStatements) — we already hold the semaphore; the
+        // *Standalone variants would deadlock here.
+        writerTransactionSemaphore.wait()
+        setWriterHolder("reset")
+        defer {
+            clearWriterHolder()
+            writerTransactionSemaphore.signal()
+        }
+
         // NOTE: Deleting files by default because it seems simpler, more reliable
         // But sadly this won't work for in-memory (shared) databases
         if isInMemoryDatabase {
@@ -351,21 +398,27 @@ public class Database {
                     throw "Could not close database".asError()
                 }
             }
-            
+
+            // MOBILE-5606: reopen on EVERY exit, including a thrown removeItem,
+            // so we never return — and never release writerTransactionSemaphore
+            // (held by the caller) — with the FMDB handles closed. Otherwise the
+            // next waiter could resume on a closed connection. open() recreates
+            // an empty DB if the files are gone, and reopens whatever remains if
+            // a removal failed mid-reset.
+            defer { open() }
+
             let manager = FileManager.default
-            
+
             try manager.removeItem(atPath: path)
-            
+
             func removeIfExists(_ path: String) throws {
                 if manager.fileExists(atPath: path) {
                     try manager.removeItem(atPath: path)
                 }
             }
-            
+
             try removeIfExists("\(path)-wal")
             try removeIfExists("\(path)-shm")
-            
-            open()
         }
     }
     

--- a/native/ios/WatermelonDB/DatabaseDriver.swift
+++ b/native/ios/WatermelonDB/DatabaseDriver.swift
@@ -120,12 +120,12 @@ class DatabaseDriver {
     
     func copyTables(_ tables: [String], srcDB: String) throws {
         // Attach the source database
-        try database.execute("ATTACH DATABASE '\(srcDB)' as 'other'")
+        try database.executeStandalone("ATTACH DATABASE '\(srcDB)' as 'other'")
 
         // Ensure DETACH always runs, even if the transaction or DELETE throws
         defer {
             do {
-                try database.execute("DETACH DATABASE 'other'")
+                try database.executeStandalone("DETACH DATABASE 'other'")
             } catch {
                 consoleLog("Warning: Failed to detach source database: \(error)")
             }
@@ -133,7 +133,7 @@ class DatabaseDriver {
 
         // We need to make sure we do not copy the __watermelon_last_pulled_schema_version entry
         // from local_storage table to avoid migration issues
-        try database.execute("DELETE FROM local_storage WHERE key = '__watermelon_last_pulled_schema_version'")
+        try database.executeStandalone("DELETE FROM local_storage WHERE key = '__watermelon_last_pulled_schema_version'")
 
          try database.inTransaction {
              for table in tables {
@@ -212,7 +212,7 @@ class DatabaseDriver {
     func destroyDeletedRecords(table: Database.TableName, records: [RecordId]) throws {
         // TODO: What's the behavior if record doesn't exist or isn't actually deleted?
         let recordPlaceholders = records.map { _ in "?" }.joined(separator: ",")
-        try database.execute("delete from `\(table)` where id in (\(recordPlaceholders))", records)
+        try database.executeStandalone("delete from `\(table)` where id in (\(recordPlaceholders))", records)
     }
     
     // MARK: - LocalStorage
@@ -228,11 +228,11 @@ class DatabaseDriver {
     }
     
     func setLocal(key: String, value: String) throws {
-        return try database.execute("insert or replace into `local_storage` (key, value) values (?, ?)", [key, value])
+        return try database.executeStandalone("insert or replace into `local_storage` (key, value) values (?, ?)", [key, value])
     }
     
     func removeLocal(key: String) throws {
-        return try database.execute("delete from `local_storage` where `key` == ?", [key])
+        return try database.executeStandalone("delete from `local_storage` where `key` == ?", [key])
     }
     
     // MARK: - Record caching

--- a/native/ios/WatermelonDBTests/BridgingHeader.h
+++ b/native/ios/WatermelonDBTests/BridgingHeader.h
@@ -1,0 +1,7 @@
+// Bridging header for the MOBILE-5606 writer-serialization test runner.
+// Exposes the React-free C/ObjC dependencies of Database.swift (FMDB + the
+// SQLite reset C shim) to Swift, the same way the pod's bridging header does.
+#import "FMDatabase.h"
+#import "FMResultSet.h"
+#import "FMDatabaseAdditions.h"
+#import "DatabaseDeleteHelper.h"

--- a/native/ios/WatermelonDBTests/main.swift
+++ b/native/ios/WatermelonDBTests/main.swift
@@ -1,0 +1,177 @@
+// MOBILE-5606 — deterministic writer-serialization tests for the iOS
+// `Database` class.
+//
+// Exercises the REAL `Database` (Database.swift) off-simulator on the macOS
+// host: it is pure Foundation + SQLite3 + FMDB, so no React/JSI/Nitro and no
+// device are required. Built + run by `run-tests.sh` (swiftc + clang).
+//
+// What it pins (the MOBILE-5606 fix = standalone writes acquire
+// `writerTransactionSemaphore` via `executeStandalone`):
+//   Test 1  — `executeStandalone` BLOCKS while a transaction holds the writer
+//             semaphore. Reverting it to bare `execute` fails this.
+//   Test 2a — a standalone write SURVIVES a concurrent transaction ROLLBACK.
+//             This is the fix: the write serializes after the rollback instead
+//             of co-mingling with it.
+//   Test 2b — a BARE `execute` issued while a transaction is open lands INSIDE
+//             that transaction and is LOST on rollback. This characterizes the
+//             bug the fix prevents (shared single writer connection).
+//
+// Exit code 0 = all pass; non-zero = failure (CI-usable).
+
+import Foundation
+
+// std_ext's `consoleLog` routes through this hook; silence it for the test.
+_watermelonDBLoggingHook = { _ in }
+
+private var failures = 0
+
+private func check(_ condition: Bool, _ message: String) {
+    if condition {
+        print("  ✓ \(message)")
+    } else {
+        print("  ✗ FAIL: \(message)")
+        failures += 1
+    }
+}
+
+private func tempDBPath() -> String {
+    let name = "wmdb-5606-\(UUID().uuidString).db"
+    return (NSTemporaryDirectory() as NSString).appendingPathComponent(name)
+}
+
+private func makeDB() -> Database {
+    let db = Database(path: tempDBPath())
+    // Single-threaded setup — safe to call the bare statement runner directly.
+    try! db.executeStatements("CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT)")
+    return db
+}
+
+private func count(_ db: Database, whereV v: String) -> Int {
+    return (try? db.count("SELECT count(*) as count FROM t WHERE v = '\(v)'")) ?? -1
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 — executeStandalone serializes behind an in-flight transaction.
+// ---------------------------------------------------------------------------
+private func test1_standaloneBlocksWhileTransactionHeld() {
+    print("Test 1: executeStandalone blocks while a transaction holds the writer semaphore")
+    let db = makeDB()
+
+    let txnHeld = DispatchSemaphore(value: 0)
+    let releaseTxn = DispatchSemaphore(value: 0)
+    let bFinished = DispatchSemaphore(value: 0)
+    var bCompleted = false
+
+    // Thread A: hold an open transaction → holds writerTransactionSemaphore.
+    DispatchQueue.global().async {
+        try? db.inTransaction {
+            txnHeld.signal()
+            releaseTxn.wait() // keep the transaction (and the semaphore) open
+        }
+    }
+    txnHeld.wait()
+
+    // Thread B: a standalone write. With the fix it must wait on the semaphore.
+    DispatchQueue.global().async {
+        try? db.executeStandalone("INSERT INTO t (v) VALUES ('B')")
+        bCompleted = true
+        bFinished.signal()
+    }
+
+    // If standalone writes weren't serialized, B would complete in this window.
+    Thread.sleep(forTimeInterval: 0.3)
+    check(!bCompleted, "standalone write did NOT complete while the transaction held the semaphore")
+
+    // Release the transaction; B should now proceed and persist.
+    releaseTxn.signal()
+    check(bFinished.wait(timeout: .now() + 5) == .success, "standalone write completed after the transaction released")
+    check(count(db, whereV: "B") == 1, "standalone write persisted (count == 1)")
+}
+
+// ---------------------------------------------------------------------------
+// Test 2a — standalone write survives a concurrent transaction ROLLBACK (FIX).
+// ---------------------------------------------------------------------------
+private func test2a_standaloneSurvivesConcurrentRollback() {
+    print("Test 2a (FIX): standalone write survives a concurrent transaction ROLLBACK")
+    let db = makeDB()
+
+    let txnHeld = DispatchSemaphore(value: 0)
+    let releaseTxn = DispatchSemaphore(value: 0)
+    let bWritten = DispatchSemaphore(value: 0)
+
+    // Thread A: open a transaction, write an uncommitted row, then ROLL BACK
+    // (inTransaction rolls back when its body throws).
+    DispatchQueue.global().async {
+        try? db.inTransaction {
+            try db.execute("INSERT INTO t (v) VALUES ('A-uncommitted')")
+            txnHeld.signal()
+            releaseTxn.wait()
+            throw "force rollback".asError()
+        }
+    }
+    txnHeld.wait()
+
+    // Thread B: standalone write. With the fix it blocks on the semaphore until
+    // A rolls back and releases, then writes in its own autocommit.
+    DispatchQueue.global().async {
+        try? db.executeStandalone("INSERT INTO t (v) VALUES ('B-standalone')")
+        bWritten.signal()
+    }
+
+    releaseTxn.signal() // A throws → rolls back → releases the semaphore
+    _ = bWritten.wait(timeout: .now() + 5)
+    Thread.sleep(forTimeInterval: 0.1) // let the autocommit settle
+
+    check(count(db, whereV: "A-uncommitted") == 0, "A's row was rolled back (count == 0)")
+    check(count(db, whereV: "B-standalone") == 1, "B's standalone write SURVIVED the rollback (count == 1)")
+}
+
+// ---------------------------------------------------------------------------
+// Test 2b — a BARE execute is LOST on rollback (characterizes the bug).
+// ---------------------------------------------------------------------------
+private func test2b_bareExecuteLostOnConcurrentRollback() {
+    print("Test 2b (BUG): a bare execute lands inside the open transaction and is LOST on rollback")
+    let db = makeDB()
+
+    let txnHeld = DispatchSemaphore(value: 0)
+    let releaseTxn = DispatchSemaphore(value: 0)
+    let bWritten = DispatchSemaphore(value: 0)
+
+    DispatchQueue.global().async {
+        try? db.inTransaction {
+            txnHeld.signal()
+            releaseTxn.wait()
+            throw "force rollback".asError()
+        }
+    }
+    txnHeld.wait()
+
+    // BARE execute (the pre-fix path): no semaphore, so it runs on the shared
+    // writer connection WHILE the transaction is open → becomes part of it. We
+    // sequence B to complete BEFORE releasing A, so the write deterministically
+    // lands inside the transaction.
+    DispatchQueue.global().async {
+        try? db.execute("INSERT INTO t (v) VALUES ('B-bare')")
+        bWritten.signal()
+    }
+    _ = bWritten.wait(timeout: .now() + 5)
+
+    releaseTxn.signal() // A rolls back, taking B's co-mingled write with it
+    Thread.sleep(forTimeInterval: 0.1)
+
+    check(count(db, whereV: "B-bare") == 0,
+          "bare execute was LOST on rollback (count == 0) — the MOBILE-5606 race the fix prevents")
+}
+
+print("MOBILE-5606 writer-serialization tests")
+test1_standaloneBlocksWhileTransactionHeld()
+test2a_standaloneSurvivesConcurrentRollback()
+test2b_bareExecuteLostOnConcurrentRollback()
+
+if failures == 0 {
+    print("\nALL PASS")
+    exit(0)
+} else {
+    print("\n\(failures) FAILURE(S)")
+    exit(1)
+}

--- a/native/ios/WatermelonDBTests/run-tests.sh
+++ b/native/ios/WatermelonDBTests/run-tests.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# MOBILE-5606 — build + run the writer-serialization tests on the macOS host.
+# Database.swift is pure Foundation + SQLite3 + FMDB (no React/JSI/Nitro), so
+# the real class compiles and runs off-device. No simulator, no Pods.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."  # → native/ios
+
+FMDB="WatermelonDB/FMDB/src/fmdb"
+TESTS="WatermelonDBTests"
+BUILD="/tmp/wmdb-5606-tests"
+SDK="$(xcrun --sdk macosx --show-sdk-path)"
+
+rm -rf "$BUILD"; mkdir -p "$BUILD"
+
+echo "== compiling ObjC deps (FMDB + reset shim) =="
+OBJC_SRCS=(
+  "$FMDB/FMDatabase.m"
+  "$FMDB/FMResultSet.m"
+  "$FMDB/FMDatabaseAdditions.m"
+  "$FMDB/FMDatabaseQueue.m"
+  "$FMDB/FMDatabasePool.m"
+  "WatermelonDB/DatabaseDeleteHelper.m"
+)
+for src in "${OBJC_SRCS[@]}"; do
+  obj="$BUILD/$(basename "${src%.m}").o"
+  clang -c -fobjc-arc -w -isysroot "$SDK" -I "$FMDB" -I WatermelonDB "$src" -o "$obj"
+done
+
+echo "== compiling Swift (real Database) + linking =="
+swiftc -o "$BUILD/wmdb5606tests" \
+  -sdk "$SDK" \
+  -import-objc-header "$TESTS/BridgingHeader.h" \
+  -Xcc -I"$FMDB" -Xcc -IWatermelonDB \
+  WatermelonDB/std_ext.swift \
+  WatermelonDB/Database.swift \
+  "$TESTS/main.swift" \
+  "$BUILD"/*.o \
+  -framework Foundation -lsqlite3
+
+echo "== running =="
+"$BUILD/wmdb5606tests"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit",
     "test": "jest --config=./jest.config.js --forceExit --detectOpenHandles --no-cache",
     "test:cpp": "native/shared/tests/run_cpp_tests.sh",
+    "test:ios:writer-serialization": "bash native/ios/WatermelonDBTests/run-tests.sh",
     "test:watch": "jest --config=./jest.config.js --watch",
     "test:coverage": "jest --config=./jest.config.js --coverage",
     "ci:check": "concurrently 'npm run test' 'npm run eslint' 'npm run typecheck' --kill-others-on-fail",


### PR DESCRIPTION
## MOBILE-5606 — iOS: serialize standalone writes against the writer semaphore

### The bug
`Database.execute` / `executeStatements` bypass `writerTransactionSemaphore` (a non-reentrant `DispatchSemaphore(1)`). Because `SliceImportDatabaseAdapter` shares the **one** writer `sqlite3` connection with the regular driver (it pulls the raw handle via `getRawConnection` → `Database.getRawPointer()` → `writer.sqliteHandle`), a standalone single-statement write issued while a slice-import / `inTransaction` `BEGIN IMMEDIATE` is open executes **inside that open transaction** → it's committed atomically with unrelated data, or **silently lost if that transaction rolls back**. `busy_timeout` does not help — it's the same connection, so no `SQLITE_BUSY` is raised. The exposed standalone callers: `setLocal`, `removeLocal`, `destroyDeletedRecords`, `copyTables` ATTACH/DETACH/DELETE-prep, and the `unsafeDestroyEverything` reset/teardown path.

### The fix
- Add `executeStandalone` / `executeStatementsStandalone` — acquire `writerTransactionSemaphore` but open **no** transaction, so `ATTACH`/`DETACH`/`VACUUM` stay legal while still serializing against in-flight writers.
- Repoint the 6 standalone callers in `DatabaseDriver` to the new helpers.
- Wrap `unsafeDestroyEverything` (vacuum / close / delete) in the semaphore and **reopen on every exit**, so a thrown `removeItem` can't release it with closed handles.
- Document the `userVersion` setter precondition (bare `execute`; safe only because its callers run inside `inTransaction`).
- **In-transaction callers** (`batch`, `copyTables` inner copy, `setUpSchema`, `migrate`) intentionally keep the **bare** methods — a blanket wrap would deadlock the non-reentrant semaphore.

### Tests
`native/ios/WatermelonDBTests/` — a deterministic **macOS-host** MRE (`swiftc`+`clang`, no simulator/Pods) that exercises the **real** `Database` class:
- **T1** — `executeStandalone` blocks while a transaction holds the semaphore.
- **T2a (fix)** — a standalone write survives a concurrent transaction rollback.
- **T2b (bug)** — a bare `execute` lands inside the open txn and is lost on rollback.

Run: `yarn test:ios:writer-serialization` (or `bash native/ios/WatermelonDBTests/run-tests.sh`) → `ALL PASS`. Wired as a first-class `test:*` script entrypoint, mirroring the existing `test:cpp` shell-test convention.
**Validated as a real guard:** neutering `executeStandalone` to bare `execute` (negative control) reproduces **3 failures** (T1 + T2a); restoring the fix → all pass.

### Verification
- ✅ Compiles in the iOS app build (DevDebug, 0 errors).
- ✅ `react-native-harness` on iPhone 17 Pro: **8/8 suites, 12/12 tests** (incl. `cold-slice-race` writer-serialization contract) — no regression.
- ✅ Deterministic native MRE above (fails-without / passes-with the fix).
- ✅ Code review + independent adversarial cross-check (the one flagged "unguarded write" path, JSI `execSqlQuery`, traced to the **read/query** path — not a write-loss gap).

### Tracked follow-ups (out of scope)
- `copyTables` is still not atomic vs a concurrent writer (pre-existing).
- Writer-connection **reads** (`queryRawOnWriter`, `execSqlQuery` for non-read-only SQL) remain unguarded vs writes — a read-consistency concern, not silent write loss.
- Auto-run `test:ios:writer-serialization` in CI. The fork currently has **no** GitHub Actions workflows — every native test (`test:cpp`/`test:ios`/`test:android`) is an opt-in script today — so a macOS CI job to auto-run this on `native/ios/**` PRs would be net-new CI infra (happy to add it if wanted).

### Rollout
This is the **fork** PR (the native change). A follow-up `buildhero-mobile` PR will bump `@BuildHero/watermelondb` `7.0.4-10 → 7.0.4-11` (mobile/common/database) once a prerelease is published from this branch.

Claude session: c1f52f82-355b-4fb4-b5a5-41dfba4e6f60

🤖 Generated with [Claude Code](https://claude.com/claude-code)
