### PR TITLE
fix(podspec): exclude WatermelonDBTests from source_files glob - MOBILE-5606

### DIFF
--- a/WatermelonDB.podspec
+++ b/WatermelonDB.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms    = { :ios => "9.0", :tvos => "9.0" }
   s.source       = { :http => 'file:' + __dir__ + '/'  }
   s.source       = { :git => "https://github.com/BuildHero/WatermelonDB", :tag => "v#{s.version}" }
-  s.source_files = "native/ios/**/*.{h,m,mm,swift,c,cpp}", "native/shared/*.{h,c,cpp}"
+  s.source_files = "native/ios/WatermelonDB/**/*.{h,m,mm,swift,c,cpp}", "native/shared/*.{h,c,cpp}"
   s.public_header_files = '**/Bridging.h'
   s.requires_arc = true
   s.dependency "React"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "7.0.4-11",
+  "version": "7.0.4-12",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",


### PR DESCRIPTION
## Summary

- The `WatermelonDB.podspec` source glob `native/ios/**/*.{h,m,mm,swift,c,cpp}` was inadvertently picking up `native/ios/WatermelonDBTests/main.swift` (added in v7.0.4-11 as a test harness for MOBILE-5606)
- `main.swift` with top-level statements produces a `_main` symbol — colliding with the app's own entry point → `duplicate symbol '_main'` → `** ARCHIVE FAILED **`
- Fix: narrow the glob to `native/ios/WatermelonDB/**/*` so the `WatermelonDBTests/` directory is excluded

## Change

```diff
- s.source_files = "native/ios/**/*.{h,m,mm,swift,c,cpp}", "native/shared/*.{h,c,cpp}"
+ s.source_files = "native/ios/WatermelonDB/**/*.{h,m,mm,swift,c,cpp}", "native/shared/*.{h,c,cpp}"
```

## Impact

Fixes the iOS CI break introduced by v7.0.4-11 on `buildhero-mobile` main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)