### PR TITLE
fix(sync): treat HTTP 304 pull-changes as an empty no-op pull - MOBILE-6204

### DIFF
--- a/native/shared/SyncEngine.cpp
+++ b/native/shared/SyncEngine.cpp
@@ -734,10 +734,20 @@ void SyncEngine::handleHttpResponse(int64_t syncId, const platform::HttpResponse
         pushChangesCb = pushChangesCallback_;
     }
 
+    // HTTP 304 Not Modified: the native pull stack (okhttp/CFNetwork) honors
+    // ETag/If-None-Match, so an empty pull comes back as 304 with an empty body.
+    // Treat it as a successful no-change pull by applying a synthesized empty
+    // envelope — this routes through the exact same downstream path as an empty 200
+    // ({"items":[]}), so the stored cursor/sequence is preserved and no pagination
+    // is triggered. Passing the empty 304 body straight to the apply callback would
+    // instead throw ("Invalid JSON payload: missing 'items' array") and fail the sync.
+    const std::string pullBody =
+        response.statusCode == 304 ? std::string("{\"items\":[]}") : response.body;
+
     std::string applyError;
 
     if (applyCb) {
-        if (!applyCb(response.body, applyError)) {
+        if (!applyCb(pullBody, applyError)) {
             CompletionCallback completionToCall;
             CompletionCallback pendingToCall;
             {
@@ -767,7 +777,7 @@ void SyncEngine::handleHttpResponse(int64_t syncId, const platform::HttpResponse
     }
 
     CursorValue nextCursor;
-    if (extractNextCursor(response.body, nextCursor)) {
+    if (extractNextCursor(pullBody, nextCursor)) {
         std::string nextUrl;
         {
             std::lock_guard<std::mutex> lock(mutex_);

--- a/native/shared/tests/SyncApplyEngineTests.cpp
+++ b/native/shared/tests/SyncApplyEngineTests.cpp
@@ -296,6 +296,32 @@ void test_updates_last_sequence_id_ulid() {
     sqlite3_close(db);
 }
 
+void test_empty_items_preserves_last_sequence_id() {
+    // SyncEngine synthesizes an empty envelope ({"items":[]}) for HTTP 304 Not Modified
+    // pulls. Applying it must succeed and leave the stored cursor untouched — a 304 means
+    // "nothing new, keep the current cursor".
+    sqlite3* db = nullptr;
+    sqlite3_open(":memory:", &db);
+    std::string error;
+    execSql(db, "CREATE TABLE tasks (id TEXT PRIMARY KEY, name TEXT)", error);
+    execSql(db, "CREATE TABLE local_storage (key TEXT PRIMARY KEY, value TEXT)", error);
+    execSql(db,
+            "INSERT INTO local_storage (key, value) "
+            "VALUES ('__watermelon_last_sequence_id', '01ARZ3NDEKTSV4RRFFQ69G5FAW')",
+            error);
+
+    bool ok = watermelondb::applySyncPayload(db, "{\"items\":[]}", error);
+    expectTrue(ok, "applySyncPayload should succeed for an empty items envelope");
+
+    std::string sequenceId;
+    expectTrue(querySingleText(db, "SELECT value FROM local_storage WHERE key='__watermelon_last_sequence_id'", sequenceId),
+               "last_sequence_id row should still exist after empty apply");
+    expectTrue(sequenceId == "01ARZ3NDEKTSV4RRFFQ69G5FAW",
+               "empty-items apply must preserve the existing cursor (304 keeps current cursor)");
+
+    sqlite3_close(db);
+}
+
 // --- Conflict resolution tests: _status preservation during sync pull ---
 
 void test_created_record_not_overwritten() {
@@ -617,6 +643,7 @@ int main() {
     test_payload_requires_envelope_object();
     test_envelope_payload_upserts_and_deletes();
     test_updates_last_sequence_id_ulid();
+    test_empty_items_preserves_last_sequence_id();
 
     // Conflict resolution tests
     test_created_record_not_overwritten();

--- a/native/shared/tests/SyncEngineTests.cpp
+++ b/native/shared/tests/SyncEngineTests.cpp
@@ -459,6 +459,83 @@ void test_apply_error_sets_state() {
     expectTrue(recorder.waitForContains("\"state\":\"error\""), "expected error state after apply failure");
 }
 
+void test_not_modified_304_is_noop_success() {
+    // HTTP 304 Not Modified: the native pull stack (okhttp/CFNetwork) honors
+    // ETag/If-None-Match, so an empty pull comes back as 304 with an empty body. That
+    // must be treated as a successful no-change pull, NOT handed to the apply callback
+    // (which mirrors the real SyncApplyEngine contract and rejects a body without a
+    // top-level "items" array). The apply callback below reproduces that throw to guard
+    // the regression.
+    //
+    // Assertions read only this engine's own completion, stateJson(), and apply-callback
+    // observations — never the shared global HTTP handler or a captured EventRecorder — so
+    // they're immune to the suite's cross-test pollution (earlier retry-based tests leave
+    // detached retry threads that can still hit the shared http handler).
+    auto engine = std::make_shared<watermelondb::SyncEngine>();
+
+    std::mutex applyMutex;
+    int applyCount = 0;
+    std::string appliedBody;
+    engine->setApplyCallback([&](const std::string& body, std::string& errorMessage) {
+        {
+            std::lock_guard<std::mutex> lock(applyMutex);
+            applyCount++;
+            appliedBody = body;
+        }
+        // Mirror SyncApplyEngine::applySyncPayload: a body without an items array throws.
+        if (body.find("\"items\"") == std::string::npos) {
+            errorMessage = "Invalid JSON payload: missing 'items' array";
+            return false;
+        }
+        return true;
+    });
+    engine->setPushChangesCallback([&](std::function<void(bool, const std::string&)> completion) {
+        completion(true, "");
+    });
+
+    watermelondb::platform::setHttpHandler([](const watermelondb::platform::HttpRequest&,
+                                              std::function<void(const watermelondb::platform::HttpResponse&)> done) {
+        watermelondb::platform::HttpResponse response;
+        response.statusCode = 304; // Not Modified, empty body
+        done(response);
+    });
+
+    std::mutex m;
+    std::condition_variable cv;
+    bool completed = false;
+    bool success = false;
+
+    engine->configure("{\"pullEndpointUrl\":\"https://example.com/pull\",\"connectionTag\":1}");
+    engine->startWithCompletion("not_modified", [&](bool s, const std::string&) {
+        {
+            std::lock_guard<std::mutex> lock(m);
+            completed = true;
+            success = s;
+        }
+        cv.notify_all();
+    });
+
+    {
+        std::unique_lock<std::mutex> lock(m);
+        cv.wait_for(lock, std::chrono::milliseconds(500), [&] { return completed; });
+    }
+
+    expectTrue(completed, "304 sync should invoke completion");
+    expectTrue(success, "304 sync should complete successfully (no-op no-change pull)");
+    expectTrue(engine->stateJson().find("\"state\":\"done\"") != std::string::npos,
+               "304 should leave engine in done state");
+    {
+        std::lock_guard<std::mutex> lock(applyMutex);
+        // A no-change pull applies at most once (no pagination) and, if apply ran, it must
+        // have received a synthesized envelope — never the empty 304 body.
+        expectTrue(applyCount <= 1, "304 no-change pull should apply at most once (no pagination)");
+        expectTrue(applyCount == 0 || appliedBody.find("\"items\"") != std::string::npos,
+                   "304 must never hand an empty body to the apply callback");
+    }
+
+    watermelondb::platform::setHttpHandler(nullptr);
+}
+
 void test_cancel_sync_when_idle() {
     EventRecorder recorder;
     auto engine = std::make_shared<watermelondb::SyncEngine>();
@@ -997,6 +1074,7 @@ int main() {
     test_missing_endpoint_error();
     test_invalid_config_json();
     test_apply_error_sets_state();
+    test_not_modified_304_is_noop_success();
     test_cancel_sync_when_idle();
     test_cancel_sync_in_flight();
     test_cancel_sync_during_auth_required();


### PR DESCRIPTION
## Summary

Nitro's native pull stack (okhttp on Android, CFNetwork on iOS) honors `ETag`/`If-None-Match`. When a `sync/pull-changes` poll is empty, the mobile-api (Express `res.json`, weak ETag) responds **HTTP 304 Not Modified with a stripped body**. The native apply engine requires a top-level `items` array and threw:

```
Invalid JSON payload: missing 'items' array
```

…which failed the **entire** `syncDatabase` run — surfaced to users as a generic "We're not able to complete this action right now" toast and a queued Failed Action (e.g. on a Form V3 save that triggered the sync). Intermittent (~12% of pulls are 304) and cross-platform.

## Change

`native/shared/SyncEngine.cpp` `handleHttpResponse`: on **304**, synthesize `{"items":[]}` and feed it through the existing apply/cursor path, so a 304 behaves identically to an empty `200`:

```cpp
const std::string pullBody =
    response.statusCode == 304 ? std::string("{\"items\":[]}") : response.body;
```

Result: applies an empty batch, **advances no cursor**, triggers **no pagination**, completes `done`/`completion(true, "")`. Chosen over short-circuiting so it reuses the exact empty-200 bookkeeping.

## Testing

MRE-first (failing → passing), built via cmake with `clang++ -std=c++17`:

- **`native/shared/tests/SyncEngineTests.cpp` → `test_not_modified_304_is_noop_success`** — a 304 + empty body completes successfully, reaches `state:done`, applies at most once (no pagination), and the apply callback never receives an empty body. Fails on the pristine engine; passes with this change.
- **`native/shared/tests/SyncApplyEngineTests.cpp` → `test_empty_items_preserves_last_sequence_id`** — applying `{"items":[]}` succeeds and leaves `__watermelon_last_sequence_id` unchanged (304 = "keep cursor").
- Full `sync_engine_tests` (5/5 runs) and `sync_apply_engine_tests` (3/3) green.

## Context / severity

- **Latent in mobile 3.78.0** — the Nitro native-HTTP foreground-sync flag is **off** there, so no user impact today. Routed to **main / next release** (not cherry-picked). It'll be in place before the flag is ever enabled.
- Not a code-diff regression — the sync sources are byte-identical to `main`; the JS→native HTTP shift in Nitro is what exposes the long-standing 304 gap.
- Evidence: LogRocket session `6-019f3e2e-0f51-7bd4-bb77-280e167dd345`; Datadog APM trace `6a4d5a0f0000000008b4bf136bbd9c8b` (`/sync/pull-changes` → 304, `items_returned:0`).
- Complementary server-side mitigation (separate, optional): `Cache-Control: no-store` / disable ETag on the pull-changes route.

## Follow-up to ship (not in this PR)

Native change — cannot go OTA. Publish fork `7.0.4-14`, then bump the `@BuildHero/watermelondb` pin in buildhero-mobile (`packages/mobile`, `packages/common`, `packages/database`) and cut a store/dev build.

Tracked by **MOBILE-6204**. Full regression report: https://claude.ai/code/artifact/614768ff-3f3e-47af-bf04-f88d41eb1e04

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRFrMk5V6wMMyXR4rtjD6y
