### PR TITLE
fix(reset): stop ErrorAdapter property getters throwing during DB reset - MOBILE-6149

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "7.0.4-17",
+  "version": "7.0.4-18",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "7.0.4-20",
+  "version": "7.0.4-21",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "7.0.4-19",
+  "version": "7.0.4-20",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "7.0.4-16",
+  "version": "7.0.4-17",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "7.0.4-15",
+  "version": "7.0.4-16",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "7.0.4-18",
+  "version": "7.0.4-19",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "7.0.4-22",
+  "version": "7.0.4-23",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "7.0.4-21",
+  "version": "7.0.4-22",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "7.0.4-14",
+  "version": "7.0.4-15",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/src/Collection/index.ts
+++ b/src/Collection/index.ts
@@ -295,7 +295,18 @@ export default class Collection<Record extends Model> {
         logger.log(`Record ${this.table}#${id} not found`)
         // @ts-ignore
         this.modelClass.fetchFromRemote(this.modelClass.table, id).then((_: void) => {
-          underlyingAdapter.find(this.table, id, (result) => {
+          // MOBILE-6149: re-read the adapter after the async gap. A reset may
+          // have started while fetchFromRemote was in flight, so the reference
+          // captured above is stale (a torn-down adapter). Fail soft rather than
+          // querying it — do not bypass the reset guard with a captured adapter.
+          const adapterAfterFetch = this.database.adapter?.underlyingAdapter
+          if (!adapterAfterFetch) {
+            callback({
+              error: new Error(`Database is resetting; cannot fetch ${this.table}#${id}`),
+            })
+            return
+          }
+          adapterAfterFetch.find(this.table, id, (result) => {
             callback(mapQueryResult(id, result) as Result<Record>)
           })
         })

--- a/src/Collection/index.ts
+++ b/src/Collection/index.ts
@@ -203,11 +203,15 @@ export default class Collection<Record extends Model> {
   _fetchQuery(query: Query<Record>, callback: ResultCallback<Record[]>): void {
     const underlyingAdapter = this.database.adapter?.underlyingAdapter
 
-    // MOBILE-6149: no adapter to query while the database is being reset —
-    // resolve with an empty result instead of dereferencing a null adapter (the
-    // forced-reset path reloads the app once the wipe settles).
+    // MOBILE-6149: the database is being reset. Report a caught error rather
+    // than a false-empty success — an empty result would be indistinguishable
+    // from "no records exist" and could drive incorrect state decisions (and
+    // would hide the illegal access). The Result flows through toPromise as a
+    // rejection, which query consumers already handle; it is not a fatal throw.
     if (!underlyingAdapter) {
-      return callback({ value: [] })
+      return callback({
+        error: new Error(`Database is resetting; cannot run query on ${this.table}`),
+      })
     }
 
     const serializedQuery = query.serialize()
@@ -242,9 +246,12 @@ export default class Collection<Record extends Model> {
   _fetchCount(query: Query<Record>, callback: ResultCallback<number>): void {
     const underlyingAdapter = this.database.adapter?.underlyingAdapter
 
-    // MOBILE-6149: fail soft while the database is being reset.
+    // MOBILE-6149: report a caught error while the database is being reset,
+    // not a false 0 count (see _fetchQuery).
     if (!underlyingAdapter) {
-      return callback({ value: 0 })
+      return callback({
+        error: new Error(`Database is resetting; cannot count ${this.table}`),
+      })
     }
 
     underlyingAdapter.count(query.serialize(), callback)

--- a/src/Collection/index.ts
+++ b/src/Collection/index.ts
@@ -65,7 +65,7 @@ export default class Collection<Record extends Model> {
     // synchronously inside RecordCache (outside any Promise/try-catch boundary),
     // so bail soft instead of issuing a native query with a null tag — a throw
     // here is a fatal, uncaught crash.
-    if (!underlyingAdapter) {
+    if (this.database._isBeingReset || !underlyingAdapter) {
       return undefined as any
     }
 
@@ -182,9 +182,13 @@ export default class Collection<Record extends Model> {
       typeof adapter.unsafeSqlQuery === 'function',
       'unsafeFetchRecordsWithSQL called on database that does not support SQL',
     )
+    const startResetCount = this.database._resetCount
     // @ts-ignore
     const rawRecords = await adapter.unsafeSqlQuery(this.modelClass.table, sql)
 
+    // MOBILE-6149: a reset may have raced the await above — abort rather than
+    // repopulate the cache with pre-reset records.
+    this._assertNotResetting(startResetCount)
     return this._cache.recordsFromQueryResult(rawRecords)
   }
 
@@ -199,14 +203,26 @@ export default class Collection<Record extends Model> {
     return this.database.schema.tables[this.table]
   }
 
-  // MOBILE-6149: throw if a reset began. Called inside query-result mappers,
-  // which run in mapValue's try/catch, so the throw becomes a rejected Result
-  // rather than a partial/null array that would violate the Query.fetch
-  // contract. Guards the in-flight-completion race: a query issued while the
-  // adapter was valid can complete during a reset, and its cache-miss resolver
-  // yields null holes — abort instead of resolving a false-success array.
-  _assertNotResetting(): void {
-    if (!this.database.adapter?.underlyingAdapter) {
+  // MOBILE-6149: throw if a database reset is racing this read. Called inside
+  // query-result mappers (which run in mapValue's try/catch) and after awaited
+  // reads, so the throw becomes a rejected Result rather than a partial/null
+  // array, a stale count, or a cache repopulated with pre-reset records.
+  //
+  // Keyed off the same signals the sync engine trusts (see
+  // sync/impl/helpers.ts isSameDatabase), covering all three race windows:
+  //  - `_isBeingReset`      → a reset is in flight (incl. the pre-adapter-swap gap)
+  //  - `!underlyingAdapter` → the ErrorAdapter placeholder is installed; also the
+  //                           failed-wipe case where `_isBeingReset` was cleared
+  //                           in `finally` but the real adapter was never restored
+  //  - `_resetCount` moved  → a read that began before a reset is COMPLETING after
+  //                           an entire reset cycle finished (stale pre-reset data)
+  _assertNotResetting(startResetCount?: number): void {
+    const db = this.database
+    if (
+      db._isBeingReset ||
+      !db.adapter?.underlyingAdapter ||
+      (startResetCount !== undefined && db._resetCount !== startResetCount)
+    ) {
       throw new Error(`Database is resetting; query on ${this.table} aborted`)
     }
   }
@@ -226,6 +242,7 @@ export default class Collection<Record extends Model> {
       })
     }
 
+    const startResetCount = this.database._resetCount
     const serializedQuery = query.serialize()
 
     const { description, associations } = serializedQuery
@@ -237,7 +254,7 @@ export default class Collection<Record extends Model> {
         (result) =>
           callback(
             mapValue((rawRecords) => {
-              this._assertNotResetting()
+              this._assertNotResetting(startResetCount)
               return mapToGraph(rawRecords, associations, this) as Record[]
             }, result),
           ),
@@ -248,7 +265,7 @@ export default class Collection<Record extends Model> {
       callback(
         mapValue(
           (rawRecords) => {
-            this._assertNotResetting()
+            this._assertNotResetting(startResetCount)
             return this._cache.recordsFromQueryResult(rawRecords) as Record[]
           },
           result,
@@ -269,7 +286,17 @@ export default class Collection<Record extends Model> {
       })
     }
 
-    underlyingAdapter.count(query.serialize(), callback)
+    // MOBILE-6149: a count issued before a reset can complete during/after it —
+    // abort rather than deliver a stale count.
+    const startResetCount = this.database._resetCount
+    underlyingAdapter.count(query.serialize(), (result) =>
+      callback(
+        mapValue((n) => {
+          this._assertNotResetting(startResetCount)
+          return n
+        }, result),
+      ),
+    )
   }
 
   // Fetches exactly one record (See: Collection.find)
@@ -298,6 +325,8 @@ export default class Collection<Record extends Model> {
       return
     }
 
+    const startResetCount = this.database._resetCount
+
     const mapQueryResult = (
       id: RecordId,
       result:
@@ -307,6 +336,11 @@ export default class Collection<Record extends Model> {
         },
     ) => {
       return mapValue((rawRecord) => {
+        // MOBILE-6149: a find issued before a reset can complete during or after
+        // it. Abort rather than build+cache a Model from pre-reset data (which
+        // would repopulate the JS cache the reset is wiping). Runs in mapValue's
+        // try/catch → becomes a rejected Result.
+        this._assertNotResetting(startResetCount)
         invariant(rawRecord, `Record ${this.table}#${id} not found`)
         return this._cache.recordFromQueryResult(rawRecord as any)
       }, result)

--- a/src/Collection/index.ts
+++ b/src/Collection/index.ts
@@ -57,8 +57,20 @@ export default class Collection<Record extends Model> {
   }
 
   _onCacheMiss(id: RecordId): Record {
-    const hasHybridJSI = this.database.adapter?.underlyingAdapter?._hybridJSIEnabled
-    const tag = this.database.adapter?.underlyingAdapter?._tag
+    const underlyingAdapter = this.database.adapter?.underlyingAdapter
+
+    // MOBILE-6149: during an in-flight unsafeResetDatabase() `database.adapter`
+    // is a placeholder whose `underlyingAdapter` is unavailable. A cache miss
+    // cannot be resolved against a database that is being wiped, and this runs
+    // synchronously inside RecordCache (outside any Promise/try-catch boundary),
+    // so bail soft instead of issuing a native query with a null tag — a throw
+    // here is a fatal, uncaught crash.
+    if (!underlyingAdapter) {
+      return undefined as any
+    }
+
+    const hasHybridJSI = underlyingAdapter._hybridJSIEnabled
+    const tag = underlyingAdapter._tag
 
     if (!hasHybridJSI) {
       invariant(id, `Record ID ${this.table}#${id} was sent over the bridge, but it's not cached`)
@@ -189,12 +201,21 @@ export default class Collection<Record extends Model> {
 
   // See: Query.fetch
   _fetchQuery(query: Query<Record>, callback: ResultCallback<Record[]>): void {
+    const underlyingAdapter = this.database.adapter?.underlyingAdapter
+
+    // MOBILE-6149: no adapter to query while the database is being reset —
+    // resolve with an empty result instead of dereferencing a null adapter (the
+    // forced-reset path reloads the app once the wipe settles).
+    if (!underlyingAdapter) {
+      return callback({ value: [] })
+    }
+
     const serializedQuery = query.serialize()
 
     const { description, associations } = serializedQuery
 
     if (description?.eagerJoinTables?.length) {
-      return this.database.adapter.underlyingAdapter.execSqlQuery(
+      return underlyingAdapter.execSqlQuery(
         encodeQuery(serializedQuery, false, this.database.schema),
         [],
         (result) =>
@@ -207,7 +228,7 @@ export default class Collection<Record extends Model> {
       )
     }
 
-    return this.database.adapter.underlyingAdapter.query(query.serialize(), (result) =>
+    return underlyingAdapter.query(query.serialize(), (result) =>
       callback(
         mapValue(
           (rawRecords) => this._cache.recordsFromQueryResult(rawRecords) as Record[],
@@ -219,7 +240,14 @@ export default class Collection<Record extends Model> {
 
   // See: Query.fetchCount
   _fetchCount(query: Query<Record>, callback: ResultCallback<number>): void {
-    this.database.adapter.underlyingAdapter.count(query.serialize(), callback)
+    const underlyingAdapter = this.database.adapter?.underlyingAdapter
+
+    // MOBILE-6149: fail soft while the database is being reset.
+    if (!underlyingAdapter) {
+      return callback({ value: 0 })
+    }
+
+    underlyingAdapter.count(query.serialize(), callback)
   }
 
   // Fetches exactly one record (See: Collection.find)
@@ -233,6 +261,18 @@ export default class Collection<Record extends Model> {
 
     if (cachedRecord) {
       callback({ value: cachedRecord })
+      return
+    }
+
+    const underlyingAdapter = this.database.adapter?.underlyingAdapter
+
+    // MOBILE-6149: the database is being reset — surface a soft error instead
+    // of dereferencing a null adapter (which would throw in an async `.then`
+    // continuation below, as an unhandled rejection).
+    if (!underlyingAdapter) {
+      callback({
+        error: new Error(`Database is resetting; cannot fetch ${this.table}#${id}`),
+      })
       return
     }
 
@@ -250,12 +290,12 @@ export default class Collection<Record extends Model> {
       }, result)
     }
 
-    this.database.adapter.underlyingAdapter.find(this.table, id, (result) => {
+    underlyingAdapter.find(this.table, id, (result) => {
       if (!result || !(result as any).value) {
         logger.log(`Record ${this.table}#${id} not found`)
         // @ts-ignore
         this.modelClass.fetchFromRemote(this.modelClass.table, id).then((_: void) => {
-          this.database.adapter.underlyingAdapter.find(this.table, id, (result) => {
+          underlyingAdapter.find(this.table, id, (result) => {
             callback(mapQueryResult(id, result) as Result<Record>)
           })
         })

--- a/src/Collection/index.ts
+++ b/src/Collection/index.ts
@@ -356,12 +356,18 @@ export default class Collection<Record extends Model> {
         logger.log(`Record ${this.table}#${id} not found`)
         // @ts-ignore
         this.modelClass.fetchFromRemote(this.modelClass.table, id).then((_: void) => {
-          // MOBILE-6149: re-read the adapter after the async gap. A reset may
-          // have started while fetchFromRemote was in flight, so the reference
-          // captured above is stale (a torn-down adapter). Fail soft rather than
-          // querying it — do not bypass the reset guard with a captured adapter.
+          // MOBILE-6149: fetchFromRemote is a real async gap — a reset may have
+          // begun (incl. the pre-adapter-swap window where the adapter is still
+          // the REAL one) or completed entirely (epoch moved) while it was in
+          // flight. Check the full canonical signal, not just the adapter
+          // reference: issuing this second find would be adapter traffic during
+          // the reset window. Fail soft instead.
           const adapterAfterFetch = this.database.adapter?.underlyingAdapter
-          if (!adapterAfterFetch) {
+          if (
+            this.database._isBeingReset ||
+            !adapterAfterFetch ||
+            this.database._resetCount !== startResetCount
+          ) {
             callback({
               error: new Error(`Database is resetting; cannot fetch ${this.table}#${id}`),
             })

--- a/src/Collection/index.ts
+++ b/src/Collection/index.ts
@@ -199,6 +199,18 @@ export default class Collection<Record extends Model> {
     return this.database.schema.tables[this.table]
   }
 
+  // MOBILE-6149: throw if a reset began. Called inside query-result mappers,
+  // which run in mapValue's try/catch, so the throw becomes a rejected Result
+  // rather than a partial/null array that would violate the Query.fetch
+  // contract. Guards the in-flight-completion race: a query issued while the
+  // adapter was valid can complete during a reset, and its cache-miss resolver
+  // yields null holes — abort instead of resolving a false-success array.
+  _assertNotResetting(): void {
+    if (!this.database.adapter?.underlyingAdapter) {
+      throw new Error(`Database is resetting; query on ${this.table} aborted`)
+    }
+  }
+
   // See: Query.fetch
   _fetchQuery(query: Query<Record>, callback: ResultCallback<Record[]>): void {
     const underlyingAdapter = this.database.adapter?.underlyingAdapter
@@ -224,10 +236,10 @@ export default class Collection<Record extends Model> {
         [],
         (result) =>
           callback(
-            mapValue(
-              (rawRecords) => mapToGraph(rawRecords, associations, this) as Record[],
-              result,
-            ),
+            mapValue((rawRecords) => {
+              this._assertNotResetting()
+              return mapToGraph(rawRecords, associations, this) as Record[]
+            }, result),
           ),
       )
     }
@@ -235,7 +247,10 @@ export default class Collection<Record extends Model> {
     return underlyingAdapter.query(query.serialize(), (result) =>
       callback(
         mapValue(
-          (rawRecords) => this._cache.recordsFromQueryResult(rawRecords) as Record[],
+          (rawRecords) => {
+            this._assertNotResetting()
+            return this._cache.recordsFromQueryResult(rawRecords) as Record[]
+          },
           result,
         ),
       ),

--- a/src/Collection/index.ts
+++ b/src/Collection/index.ts
@@ -218,13 +218,17 @@ export default class Collection<Record extends Model> {
   //                           in `finally` but the real adapter was never restored
   //  - `_resetCount` moved  → a read that began before a reset is COMPLETING after
   //                           an entire reset cycle finished (stale pre-reset data)
-  _assertNotResetting(startResetCount?: number): void {
+  _isResetting(startResetCount?: number): boolean {
     const db = this.database
-    if (
+    return (
       db._isBeingReset ||
       !db.adapter?.underlyingAdapter ||
       (startResetCount !== undefined && db._resetCount !== startResetCount)
-    ) {
+    )
+  }
+
+  _assertNotResetting(startResetCount?: number): void {
+    if (this._isResetting(startResetCount)) {
       throw new Error(`Database is resetting; query on ${this.table} aborted`)
     }
   }

--- a/src/Collection/index.ts
+++ b/src/Collection/index.ts
@@ -183,6 +183,8 @@ export default class Collection<Record extends Model> {
       'unsafeFetchRecordsWithSQL called on database that does not support SQL',
     )
     const startResetCount = this.database._resetCount
+    // MOBILE-6149: no adapter traffic if a reset is already in flight.
+    this._assertNotResetting()
     // @ts-ignore
     const rawRecords = await adapter.unsafeSqlQuery(this.modelClass.table, sql)
 
@@ -231,12 +233,13 @@ export default class Collection<Record extends Model> {
   _fetchQuery(query: Query<Record>, callback: ResultCallback<Record[]>): void {
     const underlyingAdapter = this.database.adapter?.underlyingAdapter
 
-    // MOBILE-6149: the database is being reset. Report a caught error rather
-    // than a false-empty success — an empty result would be indistinguishable
-    // from "no records exist" and could drive incorrect state decisions (and
-    // would hide the illegal access). The Result flows through toPromise as a
-    // rejection, which query consumers already handle; it is not a fatal throw.
-    if (!underlyingAdapter) {
+    // MOBILE-6149: no reads during a reset — report a caught error rather than a
+    // false-empty success (indistinguishable from "no records exist") or real
+    // adapter traffic. `_isBeingReset` covers the pre-adapter-swap window where
+    // the real adapter is still installed; `!underlyingAdapter` covers the
+    // ErrorAdapter window + the failed-wipe case. The Result flows through
+    // toPromise as a rejection, which query consumers already handle.
+    if (this.database._isBeingReset || !underlyingAdapter) {
       return callback({
         error: new Error(`Database is resetting; cannot run query on ${this.table}`),
       })
@@ -279,8 +282,8 @@ export default class Collection<Record extends Model> {
     const underlyingAdapter = this.database.adapter?.underlyingAdapter
 
     // MOBILE-6149: report a caught error while the database is being reset,
-    // not a false 0 count (see _fetchQuery).
-    if (!underlyingAdapter) {
+    // not a false 0 count or real adapter traffic (see _fetchQuery).
+    if (this.database._isBeingReset || !underlyingAdapter) {
       return callback({
         error: new Error(`Database is resetting; cannot count ${this.table}`),
       })
@@ -306,22 +309,24 @@ export default class Collection<Record extends Model> {
       return
     }
 
+    const underlyingAdapter = this.database.adapter?.underlyingAdapter
+
+    // MOBILE-6149: no reads during a reset — checked BEFORE the cache hit, since
+    // the cache still holds pre-reset records until _unsafeClearCaches runs, and
+    // before the async find below (whose `.then` continuation would otherwise
+    // throw as an unhandled rejection). `_isBeingReset` covers the
+    // pre-adapter-swap window; `!underlyingAdapter` the ErrorAdapter/failed-wipe.
+    if (this.database._isBeingReset || !underlyingAdapter) {
+      callback({
+        error: new Error(`Database is resetting; cannot fetch ${this.table}#${id}`),
+      })
+      return
+    }
+
     const cachedRecord = this._cache.get(id)
 
     if (cachedRecord) {
       callback({ value: cachedRecord })
-      return
-    }
-
-    const underlyingAdapter = this.database.adapter?.underlyingAdapter
-
-    // MOBILE-6149: the database is being reset — surface a soft error instead
-    // of dereferencing a null adapter (which would throw in an async `.then`
-    // continuation below, as an unhandled rejection).
-    if (!underlyingAdapter) {
-      callback({
-        error: new Error(`Database is resetting; cannot fetch ${this.table}#${id}`),
-      })
       return
     }
 

--- a/src/Collection/onCacheMiss-reset.test.js
+++ b/src/Collection/onCacheMiss-reset.test.js
@@ -287,6 +287,27 @@ describe('canonical reset-signal coverage (_isBeingReset + _resetCount epoch) â€
     expect(findSpy).toHaveBeenCalledTimes(1) // no second find
     expect(result.error).toBeInstanceOf(Error)
   })
+
+  it('observeCount(throttled) skips a reset tick without erroring/terminating the stream', async () => {
+    const { database, tasks } = mockDatabase()
+    const errors = []
+    const sub = tasks
+      .query()
+      .observeCount(true)
+      .subscribe({ next: () => {}, error: (e) => errors.push(e) })
+
+    // Enter the reset window, then cause a change that triggers a throttled
+    // recount â†’ _fetchCount returns { error }. The old toPromise() path errored
+    // and terminated the observable (this branch's exact target).
+    database._isBeingReset = true
+    await tasks.create((m) => {
+      m.name = 'x'
+    })
+    await new Promise((r) => setTimeout(r, 350)) // let throttleTime(250) fire
+
+    expect(errors).toHaveLength(0) // stream survived the reset tick
+    sub.unsubscribe()
+  })
 })
 
 // The CONFIRMED production crash path: a live query observer refetches

--- a/src/Collection/onCacheMiss-reset.test.js
+++ b/src/Collection/onCacheMiss-reset.test.js
@@ -1,5 +1,8 @@
 import { mockDatabase } from '../__tests__/testModels'
 import ErrorAdapter from '../adapters/error'
+import Query from '../Query'
+import * as Q from '../QueryDescription'
+import subscribeToSimpleQuery from '../observation/subscribeToSimpleQuery'
 
 // MOBILE-6149 (Android fatal right after login):
 // `_onCacheMiss` runs synchronously inside RecordCache._cachedModelForId when a
@@ -95,5 +98,38 @@ describe('Collection query paths report a caught error (not a false success) dur
     expect(() => tasks._fetchCount(query, (r) => (result = r))).not.toThrow()
     expect(result.error).toBeInstanceOf(Error)
     expect(result.value).toBeUndefined()
+  })
+})
+
+// The CONFIRMED production crash path: a live query observer refetches
+// synchronously when the collection reports an external change (native CDC
+// write → SQLITE_UPDATE_HOOK → Database.notify → collection._notifyExternalChange
+// → empty changeset → subscribeToSimpleQuery calls _fetchQuery). That refetch
+// runs OUTSIDE any Promise/try-catch, so on the pre-fix build the throwing
+// underlyingAdapter getter escaped through notify() as a fatal, uncaught crash.
+describe('query-observer external-change refetch during a reset — MOBILE-6149 (the fatal notify path)', () => {
+  it('does not throw when an external-change refetch races an in-flight reset', async () => {
+    const { database, tasks } = mockDatabase()
+    await tasks.create((m) => {
+      m.name = 'foo'
+    })
+
+    const query = new Query(tasks, [Q.where('name', 'foo')])
+    const observer = jest.fn()
+    const unsubscribe = subscribeToSimpleQuery(query, observer)
+    await new Promise(process.nextTick) // let the initial emission settle
+    expect(observer).toHaveBeenCalled()
+
+    // Reset window: WatermelonDB swaps database.adapter for the throwing
+    // ErrorAdapter placeholder for the duration of unsafeResetDatabase().
+    const fetchSpy = jest.spyOn(tasks, '_fetchQuery')
+    database.adapter = new ErrorAdapter()
+
+    // An external change triggers the synchronous _fetchQuery refetch. It must
+    // fail soft (guard → { error } → observer skips) rather than throw fatally.
+    expect(() => tasks._notifyExternalChange()).not.toThrow()
+    expect(fetchSpy).toHaveBeenCalledTimes(1) // the refetch path was exercised
+
+    unsubscribe()
   })
 })

--- a/src/Collection/onCacheMiss-reset.test.js
+++ b/src/Collection/onCacheMiss-reset.test.js
@@ -308,6 +308,36 @@ describe('canonical reset-signal coverage (_isBeingReset + _resetCount epoch) �
     expect(errors).toHaveLength(0) // stream survived the reset tick
     sub.unsubscribe()
   })
+
+  it('observeCount(throttled) LOGS a genuine error and keeps the stream alive (not silent, not terminated)', async () => {
+    // The fork's count observers (both throttled and non-throttled) are
+    // resilient by design: they log errors and keep the last value rather than
+    // terminating or surfacing to the next-only public subscribers. Assert a
+    // genuine error is LOGGED (so it's not "silently" swallowed) and the stream
+    // does not error/terminate — matching the non-throttled path.
+    const common = require('../utils/common')
+    const logErrorSpy = jest.spyOn(common, 'logError').mockImplementation(() => {})
+
+    const { tasks } = mockDatabase()
+    jest
+      .spyOn(tasks, '_fetchCount')
+      .mockImplementation((_q, cb) => cb({ error: new Error('boom') }))
+
+    const errors = []
+    const sub = tasks
+      .query()
+      .observeCount(true)
+      .subscribe({ next: () => {}, error: (e) => errors.push(e) })
+
+    await tasks.create((m) => {
+      m.name = 'y'
+    }) // triggers a throttled recount (not resetting)
+    await new Promise((r) => setTimeout(r, 350))
+
+    expect(logErrorSpy).toHaveBeenCalled() // logged — NOT silent
+    expect(errors).toHaveLength(0) // stream not terminated
+    sub.unsubscribe()
+  })
 })
 
 // The CONFIRMED production crash path: a live query observer refetches

--- a/src/Collection/onCacheMiss-reset.test.js
+++ b/src/Collection/onCacheMiss-reset.test.js
@@ -28,3 +28,46 @@ describe('Collection._onCacheMiss during an in-flight database reset — MOBILE-
     ).not.toThrow()
   })
 })
+
+describe('Collection._fetchRecord re-guards the adapter across the async fallback — MOBILE-6149', () => {
+  it('does not query a stale adapter if a reset starts during fetchFromRemote', async () => {
+    const { database, tasks } = mockDatabase()
+    const realAdapter = database.adapter.underlyingAdapter
+
+    // First find returns "not found" synchronously so the async
+    // fetchFromRemote fallback runs deterministically.
+    const findSpy = jest
+      .spyOn(realAdapter, 'find')
+      .mockImplementation((_table, _id, cb) => cb({ value: null }))
+
+    // Hold fetchFromRemote open so we can start a reset mid-flight.
+    let resolveRemote
+    jest
+      .spyOn(tasks.modelClass, 'fetchFromRemote')
+      .mockImplementation(() => new Promise((res) => (resolveRemote = res)))
+
+    let cbResult
+    tasks._fetchRecord('missing_id', (r) => {
+      cbResult = r
+    })
+
+    // First find hit the real adapter exactly once.
+    expect(findSpy).toHaveBeenCalledTimes(1)
+
+    // A reset begins while fetchFromRemote is in flight — database.adapter is
+    // swapped for the throwing ErrorAdapter placeholder.
+    database.adapter = new ErrorAdapter()
+
+    // Let the fallback proceed.
+    resolveRemote()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // The captured (now stale/torn-down) adapter must NOT be queried a second
+    // time; the re-guard surfaces a soft error instead. (Before the fix, the
+    // fallback called the captured adapter's find again → findSpy twice.)
+    expect(findSpy).toHaveBeenCalledTimes(1)
+    expect(cbResult).toBeDefined()
+    expect(cbResult.error).toBeInstanceOf(Error)
+  })
+})

--- a/src/Collection/onCacheMiss-reset.test.js
+++ b/src/Collection/onCacheMiss-reset.test.js
@@ -125,6 +125,105 @@ describe('Collection query paths report a caught error (not a false success) dur
     expect(result.error).toBeInstanceOf(Error)
     expect(result.value).toBeUndefined()
   })
+
+  it('_fetchRecord aborts an in-flight find that COMPLETES during a reset (no cache repopulation)', () => {
+    const { database, tasks } = mockDatabase()
+    const realAdapter = database.adapter.underlyingAdapter
+
+    let complete
+    jest.spyOn(realAdapter, 'find').mockImplementation((_table, _id, cb) => {
+      complete = cb
+    })
+
+    let result
+    tasks._fetchRecord('rec_1', (r) => (result = r))
+    expect(typeof complete).toBe('function')
+
+    // A reset begins while the find is in flight.
+    database.adapter = new ErrorAdapter()
+
+    // The native find returns a pre-reset raw record during the reset window.
+    // It must abort (caught error) rather than build+cache a Model that would
+    // repopulate the cache the reset is wiping.
+    expect(() =>
+      complete({ value: { id: 'rec_1', _status: 'synced' } })
+    ).not.toThrow()
+    expect(result.error).toBeInstanceOf(Error)
+    expect(result.value).toBeUndefined()
+    expect(tasks._cache.get('rec_1')).toBeFalsy()
+  })
+})
+
+// These exercise the CANONICAL reset signals (_isBeingReset + _resetCount epoch,
+// the same signals the sync engine's isSameDatabase() trusts) directly — not the
+// !underlyingAdapter proxy. The epoch case is the subtle one: a read that begins
+// before a reset and completes AFTER the entire reset cycle finishes sees a valid
+// adapter and _isBeingReset === false, yet must still be aborted (its data is
+// pre-reset). An in-flight-only check would miss it.
+describe('canonical reset-signal coverage (_isBeingReset + _resetCount epoch) — MOBILE-6149', () => {
+  it('_fetchQuery aborts a completion while _isBeingReset is true (adapter still looks valid)', () => {
+    const { database, tasks } = mockDatabase()
+    const realAdapter = database.adapter.underlyingAdapter
+    let complete
+    jest.spyOn(realAdapter, 'query').mockImplementation((_q, cb) => (complete = cb))
+
+    let result
+    tasks._fetchQuery(tasks.query(), (r) => (result = r))
+
+    // Reset in flight, adapter not yet swapped (the pre-swap window).
+    database._isBeingReset = true
+
+    expect(() => complete({ value: [{ id: 'x', _status: 'synced' }] })).not.toThrow()
+    expect(result.error).toBeInstanceOf(Error)
+    expect(result.value).toBeUndefined()
+  })
+
+  it('_fetchQuery aborts a query that COMPLETES AFTER a full reset cycle (epoch guard)', () => {
+    const { database, tasks } = mockDatabase()
+    const realAdapter = database.adapter.underlyingAdapter
+    let complete
+    jest.spyOn(realAdapter, 'query').mockImplementation((_q, cb) => (complete = cb))
+
+    let result
+    tasks._fetchQuery(tasks.query(), (r) => (result = r))
+
+    // An ENTIRE reset cycle completed: adapter restored (valid), _isBeingReset
+    // back to false — only the epoch advanced.
+    database._resetCount += 1
+
+    expect(() => complete({ value: [{ id: 'x', _status: 'synced' }] })).not.toThrow()
+    expect(result.error).toBeInstanceOf(Error)
+    expect(result.value).toBeUndefined()
+  })
+
+  it('_fetchCount aborts a completion during a reset (no stale count)', () => {
+    const { database, tasks } = mockDatabase()
+    const realAdapter = database.adapter.underlyingAdapter
+    let complete
+    jest.spyOn(realAdapter, 'count').mockImplementation((_q, cb) => (complete = cb))
+
+    let result
+    tasks._fetchCount(tasks.query(), (r) => (result = r))
+    database._isBeingReset = true
+
+    expect(() => complete({ value: 42 })).not.toThrow()
+    expect(result.error).toBeInstanceOf(Error)
+    expect(result.value).toBeUndefined()
+  })
+
+  it('unsafeFetchRecordsWithSQL aborts if a reset races the await (no cache repopulation)', async () => {
+    const { database, tasks } = mockDatabase()
+    database.adapter.unsafeSqlQuery = jest
+      .fn()
+      .mockResolvedValue([{ id: 'rec_1', _status: 'synced' }])
+
+    const pending = tasks.unsafeFetchRecordsWithSQL('SELECT * FROM mock_tasks')
+    // A full reset cycle completed while the SQL query was in flight.
+    database._resetCount += 1
+
+    await expect(pending).rejects.toThrow(/resetting/)
+    expect(tasks._cache.get('rec_1')).toBeFalsy()
+  })
 })
 
 // The CONFIRMED production crash path: a live query observer refetches

--- a/src/Collection/onCacheMiss-reset.test.js
+++ b/src/Collection/onCacheMiss-reset.test.js
@@ -256,6 +256,37 @@ describe('canonical reset-signal coverage (_isBeingReset + _resetCount epoch) â€
     expect(result.error).toBeInstanceOf(Error)
     expect(querySpy).not.toHaveBeenCalled() // no traffic to a resetting DB
   })
+
+  it('_fetchRecord issues no second-find traffic if a reset begins during fetchFromRemote (pre-swap)', async () => {
+    const { database, tasks } = mockDatabase()
+    const realAdapter = database.adapter.underlyingAdapter
+
+    // First find â†’ not found, so the async fetchFromRemote fallback runs.
+    const findSpy = jest
+      .spyOn(realAdapter, 'find')
+      .mockImplementation((_t, _i, cb) => cb({ value: null }))
+
+    let resolveRemote
+    jest
+      .spyOn(tasks.modelClass, 'fetchFromRemote')
+      .mockImplementation(() => new Promise((res) => (resolveRemote = res)))
+
+    let result
+    tasks._fetchRecord('missing_1', (r) => (result = r))
+    expect(findSpy).toHaveBeenCalledTimes(1)
+
+    // Reset begins DURING fetchFromRemote, adapter NOT yet swapped (still real).
+    // The old re-guard only checked !adapterAfterFetch and would have issued a
+    // second find (traffic) against the resetting DB.
+    database._isBeingReset = true
+
+    resolveRemote()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(findSpy).toHaveBeenCalledTimes(1) // no second find
+    expect(result.error).toBeInstanceOf(Error)
+  })
 })
 
 // The CONFIRMED production crash path: a live query observer refetches

--- a/src/Collection/onCacheMiss-reset.test.js
+++ b/src/Collection/onCacheMiss-reset.test.js
@@ -1,0 +1,30 @@
+import { mockDatabase } from '../__tests__/testModels'
+import ErrorAdapter from '../adapters/error'
+
+// MOBILE-6149 (Android fatal right after login):
+// `_onCacheMiss` runs synchronously inside RecordCache._cachedModelForId when a
+// record id streamed from a query/sync result isn't in the JS cache — a routine
+// event while sync hydrates records. It reads
+// `this.database.adapter?.underlyingAdapter?._tag`. During an in-flight
+// unsafeResetDatabase() `database.adapter` is the throwing ErrorAdapter
+// placeholder, and optional chaining does NOT short-circuit a getter that
+// throws, so this benign property read became a fatal, uncaught crash. This
+// path is inside WatermelonDB itself, so the app-side getSQLiteUnderlyingAdapter
+// guard shipped for the HomeScreen/download-slices sites cannot reach it.
+describe('Collection._onCacheMiss during an in-flight database reset — MOBILE-6149', () => {
+  it('does not throw a fatal error when a cache miss races unsafeResetDatabase()', () => {
+    const { database, tasks } = mockDatabase()
+
+    // Simulate the state WatermelonDB installs for the duration of the native
+    // wipe: database.adapter swapped for the throwing ErrorAdapter placeholder.
+    database.adapter = new ErrorAdapter()
+
+    // A record id from a query result that isn't cached triggers _onCacheMiss.
+    // Before the fix this threw
+    //   "Cannot call database.adapter.underlyingAdapter while the database is being reset"
+    // synchronously, outside any Promise/try-catch boundary → fatal red screen.
+    expect(() =>
+      tasks._cache.recordsFromQueryResult(['task_not_in_cache'])
+    ).not.toThrow()
+  })
+})

--- a/src/Collection/onCacheMiss-reset.test.js
+++ b/src/Collection/onCacheMiss-reset.test.js
@@ -71,3 +71,29 @@ describe('Collection._fetchRecord re-guards the adapter across the async fallbac
     expect(cbResult.error).toBeInstanceOf(Error)
   })
 })
+
+describe('Collection query paths report a caught error (not a false success) during reset — MOBILE-6149', () => {
+  it('_fetchQuery surfaces an error result, not an empty-success', () => {
+    const { database, tasks } = mockDatabase()
+    const query = tasks.query()
+    database.adapter = new ErrorAdapter()
+
+    let result
+    expect(() => tasks._fetchQuery(query, (r) => (result = r))).not.toThrow()
+    // A caught error — NOT { value: [] }, which would be indistinguishable from
+    // a genuinely empty table and could mislead callers.
+    expect(result.error).toBeInstanceOf(Error)
+    expect(result.value).toBeUndefined()
+  })
+
+  it('_fetchCount surfaces an error result, not a false 0 count', () => {
+    const { database, tasks } = mockDatabase()
+    const query = tasks.query()
+    database.adapter = new ErrorAdapter()
+
+    let result
+    expect(() => tasks._fetchCount(query, (r) => (result = r))).not.toThrow()
+    expect(result.error).toBeInstanceOf(Error)
+    expect(result.value).toBeUndefined()
+  })
+})

--- a/src/Collection/onCacheMiss-reset.test.js
+++ b/src/Collection/onCacheMiss-reset.test.js
@@ -99,6 +99,32 @@ describe('Collection query paths report a caught error (not a false success) dur
     expect(result.error).toBeInstanceOf(Error)
     expect(result.value).toBeUndefined()
   })
+
+  it('_fetchQuery aborts an in-flight query that COMPLETES during a reset (no false-success)', () => {
+    const { database, tasks } = mockDatabase()
+    const realAdapter = database.adapter.underlyingAdapter
+
+    // Capture the native completion callback so we can fire it AFTER a reset
+    // has started — the query was issued while the adapter was still valid.
+    let complete
+    jest.spyOn(realAdapter, 'query').mockImplementation((_q, cb) => {
+      complete = cb
+    })
+
+    let result
+    tasks._fetchQuery(tasks.query(), (r) => (result = r))
+    expect(typeof complete).toBe('function')
+
+    // A reset begins while the query is in flight.
+    database.adapter = new ErrorAdapter()
+
+    // The native query returns during the reset window with raw rows. The
+    // result mapper must abort (caught error) rather than resolve a partial /
+    // null-holed array that would violate the Query.fetch Record[] contract.
+    expect(() => complete({ value: [{ id: 'x', _status: 'synced' }] })).not.toThrow()
+    expect(result.error).toBeInstanceOf(Error)
+    expect(result.value).toBeUndefined()
+  })
 })
 
 // The CONFIRMED production crash path: a live query observer refetches

--- a/src/Collection/onCacheMiss-reset.test.js
+++ b/src/Collection/onCacheMiss-reset.test.js
@@ -224,6 +224,38 @@ describe('canonical reset-signal coverage (_isBeingReset + _resetCount epoch) �
     await expect(pending).rejects.toThrow(/resetting/)
     expect(tasks._cache.get('rec_1')).toBeFalsy()
   })
+
+  it('_fetchRecord aborts a CACHE HIT during a reset (no stale cached record)', async () => {
+    const { database, tasks } = mockDatabase()
+    const rec = await tasks.create((m) => {
+      m.name = 'x'
+    })
+    expect(tasks._cache.get(rec.id)).toBeTruthy() // it's cached
+
+    // Reset in flight — the cache still holds the pre-reset record.
+    database._isBeingReset = true
+
+    let result
+    tasks._fetchRecord(rec.id, (r) => (result = r))
+    // Aborted, NOT served from cache as { value: rec }.
+    expect(result.error).toBeInstanceOf(Error)
+    expect(result.value).toBeUndefined()
+  })
+
+  it('_fetchQuery issues no adapter traffic if a reset is in flight (pre-swap window)', () => {
+    const { database, tasks } = mockDatabase()
+    const realAdapter = database.adapter.underlyingAdapter
+    const querySpy = jest.spyOn(realAdapter, 'query')
+
+    // Reset in flight, adapter NOT yet swapped — still the real adapter.
+    database._isBeingReset = true
+
+    let result
+    tasks._fetchQuery(tasks.query(), (r) => (result = r))
+
+    expect(result.error).toBeInstanceOf(Error)
+    expect(querySpy).not.toHaveBeenCalled() // no traffic to a resetting DB
+  })
 })
 
 // The CONFIRMED production crash path: a live query observer refetches

--- a/src/Database/test.js
+++ b/src/Database/test.js
@@ -61,11 +61,20 @@ describe('Database', () => {
 
       const resetPromise = database.action(() => database.unsafeResetDatabase())
 
-      expect(() => database.adapter.underlyingAdapter).toThrow(
-        /Cannot call database.adapter.underlyingAdapter while the database is being reset/,
-      )
-      expect(() => database.adapter.schema).toThrow(/Cannot call database.adapter.schema/)
-      expect(() => database.adapter.migrations).toThrow(/Cannot call database.adapter.migrations/)
+      // MOBILE-6149: property GETTERS return undefined (not throw) during a
+      // reset. Callers inspect them via optional chaining / `&&` — including
+      // WatermelonDB's own query path (Collection._onCacheMiss) — and a throwing
+      // getter is not short-circuited by `?.`, so a benign property read during
+      // an in-flight reset was a fatal, uncaught crash.
+      expect(() => database.adapter.underlyingAdapter).not.toThrow()
+      expect(database.adapter.underlyingAdapter).toBeUndefined()
+      expect(() => database.adapter.schema).not.toThrow()
+      expect(database.adapter.schema).toBeUndefined()
+      expect(() => database.adapter.migrations).not.toThrow()
+      expect(database.adapter.migrations).toBeUndefined()
+
+      // Imperative METHODS still throw: a real database operation mid-reset is
+      // genuinely illegal and must fail loudly.
       expect(() => database.adapter.getLocal('test')).toThrow(
         /Cannot call database.adapter.getLocal/,
       )

--- a/src/adapters/error.test.ts
+++ b/src/adapters/error.test.ts
@@ -1,0 +1,38 @@
+import ErrorAdapter from './error'
+
+describe('ErrorAdapter (reset placeholder) — MOBILE-6149', () => {
+  it('throws on imperative method calls while the database is being reset', () => {
+    const adapter: any = new ErrorAdapter()
+
+    expect(() => adapter.query()).toThrow(/while the database is being reset/)
+    expect(() => adapter.batch()).toThrow(/while the database is being reset/)
+    expect(() => adapter.find()).toThrow(/while the database is being reset/)
+    expect(() => adapter.unsafeResetDatabase()).toThrow(/while the database is being reset/)
+  })
+
+  // Reproduces the remaining MOBILE-6149 crash. WatermelonDB's own query path
+  // (Collection._onCacheMiss reads `database.adapter?.underlyingAdapter?._tag`,
+  // Database CDC toggles read `this.adapter.underlyingAdapter`) inspects the
+  // adapter's *property getters* via optional chaining / `&&`. Optional
+  // chaining does NOT short-circuit a getter that THROWS — it only guards
+  // null/undefined — so a benign property read during an in-flight
+  // unsafeResetDatabase() became a fatal, uncaught crash on Android right after
+  // login. Property getters must return `undefined`, not throw; only the
+  // imperative methods (find/query/batch/…) represent genuinely-illegal
+  // operations during a reset and keep throwing.
+  it('does not throw when reading property getters via optional chaining', () => {
+    const adapter: any = new ErrorAdapter()
+
+    expect(() => adapter?.underlyingAdapter).not.toThrow()
+    expect(adapter?.underlyingAdapter).toBeUndefined()
+
+    // The exact fork-internal reads that crashed (Collection._onCacheMiss):
+    expect(() => adapter?.underlyingAdapter?._hybridJSIEnabled).not.toThrow()
+    expect(() => adapter?.underlyingAdapter?._tag).not.toThrow()
+
+    expect(() => adapter?.schema).not.toThrow()
+    expect(adapter?.schema).toBeUndefined()
+    expect(() => adapter?.migrations).not.toThrow()
+    expect(adapter?.migrations).toBeUndefined()
+  })
+})

--- a/src/adapters/error.ts
+++ b/src/adapters/error.ts
@@ -2,8 +2,23 @@
 
 /* eslint-disable getter-return */
 
-// Used as a placeholder during reset database to catch illegal
-// adapter calls
+// Placeholder adapter installed on `database.adapter` for the duration of
+// `unsafeResetDatabase()` (see Database/index.ts) to catch code that touches
+// the adapter while the native database is being wiped.
+//
+// Imperative METHODS (find/query/batch/getLocal/…) throw: issuing a real
+// database operation mid-reset is genuinely illegal and should fail loudly.
+//
+// Property GETTERS (underlyingAdapter/schema/migrations) return `undefined`
+// instead of throwing. Callers inspect these defensively via optional chaining
+// / `&&` — both in the app and inside WatermelonDB's own query path (e.g.
+// Collection._onCacheMiss reads `database.adapter?.underlyingAdapter?._tag`,
+// Database CDC toggles read `this.adapter.underlyingAdapter`). Optional
+// chaining does NOT short-circuit a getter that throws, so a throwing getter
+// turned a benign property read during an in-flight reset into a fatal,
+// uncaught crash (MOBILE-6149: Android fatal right after login). Returning
+// `undefined` keeps those nullish-safe reads working — they simply observe
+// "no adapter available while resetting" and no-op.
 
 const throwError = (name: string) => {
   throw new Error(`Cannot call database.adapter.${name} while the database is being reset`)
@@ -29,15 +44,15 @@ export default class ErrorAdapter {
     })
   }
 
-  get underlyingAdapter(): void {
-    throwError('underlyingAdapter')
+  get underlyingAdapter(): undefined {
+    return undefined
   }
 
-  get schema(): void {
-    throwError('schema')
+  get schema(): undefined {
+    return undefined
   }
 
-  get migrations(): void {
-    throwError('migrations')
+  get migrations(): undefined {
+    return undefined
   }
 }

--- a/src/observation/subscribeToCount/index.ts
+++ b/src/observation/subscribeToCount/index.ts
@@ -1,6 +1,5 @@
 import {Observable, switchMap, distinctUntilChanged, throttleTime} from '../../utils/rx';
 import { logError } from '../../utils/common'
-import { toPromise } from '../../utils/fp/Result'
 import { Unsubscribe } from '../../utils/subscriptions'
 
 import type Query from '../../Query'
@@ -22,7 +21,26 @@ function observeCountThrottled<Record extends Model>(query: Query<Record>): Obse
   return collection.database.withChangesForTables(query.allTables).pipe(
     throttleTime(250), // Note: this has a bug, but we'll delete it anyway
     // @ts-ignore
-    switchMap(() => toPromise(callback => collection._fetchCount(query, callback))),
+    switchMap(
+      () =>
+        // MOBILE-6149: _fetchCount returns { error } during a reset. The old
+        // toPromise() path REJECTED, which errored and permanently TERMINATED
+        // this count observable (and the subscribe below has no error handler →
+        // uncaught). Map the Result to an observable that treats a reset-window
+        // error as "skip this tick" (complete with no emission), matching the
+        // non-throttled path, so the stream stays alive and resumes after reset.
+        new Observable<number>((observer) => {
+          collection._fetchCount(query, (result) => {
+            if ((result as any).error) {
+              logError((result as any).error.toString())
+              observer.complete()
+              return
+            }
+            observer.next((result as any).value)
+            observer.complete()
+          })
+        }),
+    ),
     distinctUntilChanged(),
   )
 }

--- a/src/observation/subscribeToCount/index.ts
+++ b/src/observation/subscribeToCount/index.ts
@@ -26,9 +26,12 @@ function observeCountThrottled<Record extends Model>(query: Query<Record>): Obse
         // MOBILE-6149: _fetchCount returns { error } during a reset. The old
         // toPromise() path REJECTED, which errored and permanently TERMINATED
         // this count observable (and the subscribe below has no error handler →
-        // uncaught). Map the Result to an observable that treats a reset-window
-        // error as "skip this tick" (complete with no emission), matching the
-        // non-throttled path, so the stream stays alive and resumes after reset.
+        // uncaught). Map the Result to an observable that LOGS and skips the tick
+        // (complete with no emission) on any error, exactly matching the
+        // non-throttled path (below) and the fork's established count-observer
+        // design: counts are resilient (log + keep the last value + retry on the
+        // next change), and errors are never surfaced to the next-only public
+        // subscribers. Reset-window errors are the expected case here.
         new Observable<number>((observer) => {
           collection._fetchCount(query, (result) => {
             if ((result as any).error) {


### PR DESCRIPTION
## Problem — MOBILE-6149 (Android fatal right after login)

WatermelonDB's **own** query path reads `database.adapter?.underlyingAdapter`:
- `Collection._onCacheMiss` — on *every* cache miss (routine while sync hydrates records)
- `Database` CDC toggles (`enableNativeCDC`/`disableNativeCDC`) and `setDatabase`
- the `Collection._fetchQuery/_fetchCount/_fetchRecord` hybrid-JSI fast-paths

During an in-flight `unsafeResetDatabase()`, `database.adapter` is the `ErrorAdapter` placeholder whose `underlyingAdapter` getter **throws**. **Optional chaining does not short-circuit a getter that throws** — it only guards null/undefined — so a benign property read that races a reset became a *fatal, uncaught* crash:

```
Cannot call database.adapter.underlyingAdapter while the database is being reset
```

This is inside the library, so the app-side `getSQLiteUnderlyingAdapter()` guard shipped earlier for the HomeScreen/download-slices sites (buildhero-mobile #6327/#6328) cannot reach it. Reproduced by QA on **3.79.0 build 6640** (a build that already carries that app-side guard), ~67s after login, in `_onCacheMiss`.

## Fix

- **`adapters/error.ts`** — property getters `underlyingAdapter`/`schema`/`migrations` now return `undefined` instead of throwing. They're *inspections*, read defensively via `?.`/`&&`; a throwing getter breaks that contract. Imperative **methods** (`find`/`query`/`batch`/`getLocal`/…) still throw — a real DB operation mid-reset is genuinely illegal.
- **`Collection/index.ts`** — `_onCacheMiss` bails soft (returns `undefined`) when the underlying adapter is unavailable (the confirmed-fatal synchronous path — it runs inside `RecordCache`, outside any Promise/try-catch). `_fetchQuery/_fetchCount/_fetchRecord` fail-soft (empty / 0 / soft-error) instead of dereferencing a null adapter.
- **`Database/test.js`** — updated the reset-guard test: getters assert no-throw + `undefined`; methods still assert throw.

## Tests (MRE red→green)

- `adapters/error.test.ts` — getters return `undefined`, methods still throw.
- `Collection/onCacheMiss-reset.test.js` — reproduces the **exact production crash stack** (`_onCacheMiss` ← `RecordCache._cachedModelForId` ← `recordsFromQueryResult`). Red before the fix, green after.
- Full suite: **58 suites / 653 tests green**; `yarn typecheck` clean; `yarn build` clean.

Published as `@BuildHero/watermelondb@7.0.4-15` (tag `next`) for the mobile bump PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kft9G35YCydTW1hKp63R3j