### PR TITLE
feat(sync): native pull surfaces a changeset; JS reconciles via notify(changeSet) - MOBILE-6276

### DIFF
--- a/native/android/src/main/cpp/JSIAndroidBridgeModule.cpp
+++ b/native/android/src/main/cpp/JSIAndroidBridgeModule.cpp
@@ -244,7 +244,7 @@ JSIAndroidBridgeModule::JSIAndroidBridgeModule(std::shared_ptr<CallInvoker> jsIn
     syncEngine_->setEventCallback([this](const std::string &eventJson) {
         emitSyncEventLocked(eventJson);
     });
-    syncEngine_->setApplyCallback([this](const std::string &payload, std::string &errorMessage) {
+    syncEngine_->setApplyCallback([this](const std::string &payload, std::string &errorMessage, watermelondb::SyncChangeset &changeset) {
         if (syncConnectionTag_ <= 0) {
             errorMessage = "Missing connectionTag in sync config";
             return false;
@@ -260,7 +260,7 @@ JSIAndroidBridgeModule::JSIAndroidBridgeModule(std::shared_ptr<CallInvoker> jsIn
             errorMessage = error;
             return false;
         }
-        bool ok = watermelondb::applySyncPayload(db, payload, errorMessage);
+        bool ok = watermelondb::applySyncPayload(db, payload, errorMessage, changeset);
         releaseSqlite(databaseBridge, (jint)syncConnectionTag_);
         return ok;
     });
@@ -532,21 +532,36 @@ jsi::Value JSIAndroidBridgeModule::syncDatabaseAsync(jsi::Runtime &rt, jsi::Stri
     auto jsInvoker = jsInvoker_;
     const std::string reasonUtf8 = reason.utf8(rt);
     
-    return createPromiseAsJSIValue(rt, [engine, jsInvoker, reasonUtf8](jsi::Runtime &rt2, std::shared_ptr<Promise> promise) {
+    return createPromiseAsJSIValue(rt, [engine, jsInvoker, state, reasonUtf8](jsi::Runtime &rt2, std::shared_ptr<Promise> promise) {
         if (!engine) {
             jsInvoker->invokeAsync([promise]() mutable {
                 promise->reject("Sync engine not available");
             });
             return;
         }
-        engine->startWithCompletion(reasonUtf8, [jsInvoker, promise](bool success, const std::string& errorMessage) mutable {
-            jsInvoker->invokeAsync([promise, success, errorMessage]() mutable {
-                if (!success) {
-                    const std::string message = errorMessage.empty() ? "Sync failed" : errorMessage;
-                    promise->reject(message);
-                } else {
-                    promise->resolve(jsi::Value::undefined());
+        engine->startWithCompletion(reasonUtf8, [engine, jsInvoker, state, promise](bool success, const std::string& errorMessage) mutable {
+            // MOBILE-6276: read the pulled changeset on EVERY outcome (success, pull failure, push
+            // failure) synchronously in the completion body (before a queued sync can reset it). The
+            // pull already committed to SQLite, so JS must refresh those rows even when the push leg
+            // fails. Resolve a { "changeset": <obj>, "error": <null|string> } envelope — SyncManager
+            // applies the changeset then rethrows the error, preserving the caller's pass/fail contract.
+            const std::string changesetJson = engine->takeAccumulatedChangesetJson();
+            jsInvoker->invokeAsync([promise, success, errorMessage, changesetJson, state]() mutable {
+                if (!state) {
+                    promise->reject("Sync runtime unavailable");
+                    return;
                 }
+                const std::lock_guard<std::mutex> lock(state->mutex);
+                if (!state->alive || !state->runtime) {
+                    promise->reject("Sync runtime unavailable");
+                    return;
+                }
+                jsi::Runtime &rt3 = *state->runtime;
+                const std::string envelope = std::string("{\"changeset\":") + changesetJson + ",\"error\":" +
+                    (success ? std::string("null")
+                             : (std::string("\"") + watermelondb::json_utils::escapeJsonString(errorMessage) + "\"")) +
+                    "}";
+                promise->resolve(jsi::String::createFromUtf8(rt3, envelope));
             });
         });
     });

--- a/native/ios/WatermelonDB/JSISwiftWrapper/JSISwiftWrapperModule.mm
+++ b/native/ios/WatermelonDB/JSISwiftWrapper/JSISwiftWrapperModule.mm
@@ -56,7 +56,7 @@ JSISwiftWrapperModule::JSISwiftWrapperModule(std::shared_ptr<CallInvoker> jsInvo
     syncEngine_->setEventCallback([this](const std::string &eventJson) {
         emitSyncEventLocked(eventJson);
     });
-    syncEngine_->setApplyCallback([this](const std::string &payload, std::string &errorMessage) {
+    syncEngine_->setApplyCallback([this](const std::string &payload, std::string &errorMessage, watermelondb::SyncChangeset &changeset) {
         @autoreleasepool {
             RCTBridge *bridge = [RCTBridge currentBridge];
             DatabaseBridge *db = [bridge moduleForClass: DatabaseBridge.class];
@@ -97,7 +97,7 @@ JSISwiftWrapperModule::JSISwiftWrapperModule(std::shared_ptr<CallInvoker> jsInvo
                 return false;
             }
             NSTimeInterval applyStart = diagOn ? [NSDate timeIntervalSinceReferenceDate] : 0;
-            bool result = watermelondb::applySyncPayload(sqlite, payload, errorMessage);
+            bool result = watermelondb::applySyncPayload(sqlite, payload, errorMessage, changeset);
             if (diagOn) {
                 double applyMs = ([NSDate timeIntervalSinceReferenceDate] - applyStart) * 1000.0;
                 if (!result) {
@@ -310,21 +310,36 @@ jsi::Value JSISwiftWrapperModule::syncDatabaseAsync(jsi::Runtime &rt, jsi::Strin
     auto jsInvoker = jsInvoker_;
     const std::string reasonUtf8 = reason.utf8(rt);
     
-    return createPromiseAsJSIValue(rt, [engine, jsInvoker, reasonUtf8](jsi::Runtime &rt2, std::shared_ptr<Promise> promise) {
+    return createPromiseAsJSIValue(rt, [engine, jsInvoker, state, reasonUtf8](jsi::Runtime &rt2, std::shared_ptr<Promise> promise) {
         if (!engine) {
             jsInvoker->invokeAsync([promise]() mutable {
                 promise->reject("Sync engine not available");
             });
             return;
         }
-        engine->startWithCompletion(reasonUtf8, [jsInvoker, promise](bool success, const std::string& errorMessage) mutable {
-            jsInvoker->invokeAsync([promise, success, errorMessage]() mutable {
-                if (!success) {
-                    const std::string message = errorMessage.empty() ? "Sync failed" : errorMessage;
-                    promise->reject(message);
-                } else {
-                    promise->resolve(jsi::Value::undefined());
+        engine->startWithCompletion(reasonUtf8, [engine, jsInvoker, state, promise](bool success, const std::string& errorMessage) mutable {
+            // MOBILE-6276: read the pulled changeset on EVERY outcome (success, pull failure, push
+            // failure) synchronously in the completion body (before a queued sync can reset it). The
+            // pull already committed to SQLite, so JS must refresh those rows even when the push leg
+            // fails. Resolve a { "changeset": <obj>, "error": <null|string> } envelope — SyncManager
+            // applies the changeset then rethrows the error, preserving the caller's pass/fail contract.
+            const std::string changesetJson = engine->takeAccumulatedChangesetJson();
+            jsInvoker->invokeAsync([promise, success, errorMessage, changesetJson, state]() mutable {
+                if (!state) {
+                    promise->reject("Sync runtime unavailable");
+                    return;
                 }
+                const std::lock_guard<std::mutex> lock(state->mutex);
+                if (!state->alive || !state->runtime) {
+                    promise->reject("Sync runtime unavailable");
+                    return;
+                }
+                jsi::Runtime &rt3 = *state->runtime;
+                const std::string envelope = std::string("{\"changeset\":") + changesetJson + ",\"error\":" +
+                    (success ? std::string("null")
+                             : (std::string("\"") + watermelondb::json_utils::escapeJsonString(errorMessage) + "\"")) +
+                    "}";
+                promise->resolve(jsi::String::createFromUtf8(rt3, envelope));
             });
         });
     });

--- a/native/shared/SyncApplyEngine.cpp
+++ b/native/shared/SyncApplyEngine.cpp
@@ -359,6 +359,13 @@ static bool applyRowObject(sqlite3* db, const std::string& table, const JsonValu
         std::vector<std::string> keys;
         keys.reserve(rowValue.objectValue.size());
         for (const auto& kv : rowValue.objectValue) {
+            // MOBILE-6276: never take _status/_changed from the server payload — they are
+            // sync metadata that this engine sets itself below. Skipping them (rather than
+            // binding them) both ignores a stray server value and avoids a duplicate column
+            // in the INSERT when the literals are appended.
+            if (kv.first == "_status" || kv.first == "_changed") {
+                continue;
+            }
             if (allowedColumns->find(kv.first) != allowedColumns->end()) {
                 keys.push_back(kv.first);
             } else {
@@ -404,7 +411,22 @@ static bool applyRowObject(sqlite3* db, const std::string& table, const JsonValu
         columns += quoteIdentifier(keys[i]);
         placeholders += "?";
     }
-    
+
+    // MOBILE-6276: a full overwrite must mark the row synced, mirroring the legacy JS
+    // prepareCreateFromRaw path (_status='synced', _changed=''). Without this the row keeps
+    // whatever these columns defaulted to (NULL on a fresh INSERT OR REPLACE), which makes it
+    // invisible to the app's `_status != 'deleted'` filters. Guarded on column existence so
+    // non-synced tables (e.g. local_storage/settings) are unaffected. keys is non-empty here
+    // (id is required above), so columns/placeholders already have a leading term.
+    if (allowedColumns->find("_status") != allowedColumns->end()) {
+        columns += "," + quoteIdentifier("_status");
+        placeholders += ",'synced'";
+    }
+    if (allowedColumns->find("_changed") != allowedColumns->end()) {
+        columns += "," + quoteIdentifier("_changed");
+        placeholders += ",''";
+    }
+
     std::string sql = "INSERT OR REPLACE INTO " + quoteIdentifier(table) +
     " (" + columns + ") VALUES (" + placeholders + ")";
     
@@ -785,6 +807,12 @@ static std::string formatTableCounts(const std::unordered_map<std::string, size_
 } // namespace
 
 bool applySyncPayload(sqlite3* db, const std::string& payload, std::string& errorMessage) {
+    SyncChangeset ignored;
+    return applySyncPayload(db, payload, errorMessage, ignored);
+}
+
+bool applySyncPayload(sqlite3* db, const std::string& payload, std::string& errorMessage,
+                      SyncChangeset& changeset) {
     if (!db) {
         errorMessage = "SQLite db is null";
         return false;
@@ -829,6 +857,12 @@ bool applySyncPayload(sqlite3* db, const std::string& payload, std::string& erro
     size_t totalMerged = 0;
     std::unordered_map<std::string, size_t> skippedDirtyByTable;
     std::unordered_map<std::string, size_t> mergedByTable;
+
+    // MOBILE-6276: ids actually written (upsert or partial-merge) / hard-deleted this page, so the
+    // caller can tell the JS layer exactly what changed instead of guessing. Folded into `changeset`
+    // only after COMMIT succeeds.
+    std::unordered_map<std::string, std::vector<std::string>> upsertedIdsByTable;
+    std::unordered_map<std::string, std::vector<std::string>> deletedIdsByTable;
 
     for (const auto& entry : items->arrayValue) {
         if (entry.type != JsonValue::Type::Object) {
@@ -883,6 +917,12 @@ bool applySyncPayload(sqlite3* db, const std::string& payload, std::string& erro
                 execSql(db, "ROLLBACK", errorMessage);
                 return false;
             }
+            // Capture the id string before deleteId is moved into the delete array below.
+            const std::string deleteIdStr = (deleteId.type == JsonValue::Type::String)
+                                                ? deleteId.stringValue
+                                                : (deleteId.type == JsonValue::Type::Number)
+                                                      ? deleteId.numberValue
+                                                      : std::string();
             JsonValue& deleteArray = deletesByTable[table];
             if (deleteArray.type != JsonValue::Type::Array) {
                 deleteArray.type = JsonValue::Type::Array;
@@ -891,6 +931,9 @@ bool applySyncPayload(sqlite3* db, const std::string& payload, std::string& erro
             deleteArray.arrayValue.emplace_back(std::move(deleteId));
             totalDeletes++;
             deletesCountByTable[table]++;
+            if (!deleteIdStr.empty()) {
+                deletedIdsByTable[table].push_back(deleteIdStr);
+            }
         } else {
             if (!rowPtr || rowPtr->type != JsonValue::Type::Object) {
                 errorMessage = "Invalid row payload";
@@ -938,6 +981,9 @@ bool applySyncPayload(sqlite3* db, const std::string& payload, std::string& erro
                 }
                 totalMerged++;
                 mergedByTable[table]++;
+                if (!recordId.empty()) {
+                    upsertedIdsByTable[table].push_back(recordId);
+                }
             } else {
                 // Record is synced or new — full overwrite
                 if (!applyRowObject(db, table, *rowPtr, errorMessage)) {
@@ -946,6 +992,9 @@ bool applySyncPayload(sqlite3* db, const std::string& payload, std::string& erro
                 }
                 totalUpserts++;
                 upsertsByTable[table]++;
+                if (!recordId.empty()) {
+                    upsertedIdsByTable[table].push_back(recordId);
+                }
             }
         }
     }
@@ -968,7 +1017,18 @@ bool applySyncPayload(sqlite3* db, const std::string& payload, std::string& erro
     if (!execSql(db, "COMMIT", errorMessage)) {
         return false;
     }
-    
+
+    // MOBILE-6276: only after the page's transaction commits, append its committed ids into the
+    // caller's accumulator (so a rolled-back page never leaks into the reported changeset).
+    for (auto& kv : upsertedIdsByTable) {
+        auto& dst = changeset[kv.first].upserted;
+        dst.insert(dst.end(), kv.second.begin(), kv.second.end());
+    }
+    for (auto& kv : deletedIdsByTable) {
+        auto& dst = changeset[kv.first].deleted;
+        dst.insert(dst.end(), kv.second.begin(), kv.second.end());
+    }
+
     const std::string upsertsSummary = formatTableCounts(upsertsByTable);
     const std::string deletesSummary = formatTableCounts(deletesCountByTable);
     std::string message = "SyncApplyEngine batch applied: items=" + std::to_string(totalItems) +

--- a/native/shared/SyncApplyEngine.h
+++ b/native/shared/SyncApplyEngine.h
@@ -1,10 +1,60 @@
 #pragma once
 
+#include "JsonUtils.h"
+
 #include <sqlite3.h>
+#include <map>
 #include <string>
+#include <vector>
 
 namespace watermelondb {
 
+// MOBILE-6276: the set of record ids a pull actually wrote (upserted: full-overwrite or
+// partial-merge) or hard-deleted, per table. Locally-dirty rows the engine skips are NOT recorded.
+struct TableChangeset {
+    std::vector<std::string> upserted;
+    std::vector<std::string> deleted;
+};
+
+// std::map keeps table order deterministic (sorted) for stable JSON + test assertions.
+using SyncChangeset = std::map<std::string, TableChangeset>;
+
+// Applies a pulled page to SQLite and APPENDS the ids it committed into `changeset`
+// (so a caller can accumulate across paginated pages). Returns false on parse/apply error.
+bool applySyncPayload(sqlite3* db, const std::string& payload, std::string& errorMessage,
+                      SyncChangeset& changeset);
+
+// Back-compat overload for callers that don't need the changeset.
 bool applySyncPayload(sqlite3* db, const std::string& payload, std::string& errorMessage);
+
+// Serializes a changeset to `{"<table>":{"upserted":[...],"deleted":[...]}}`. Empty -> "{}".
+// Header-only (no SQLite) so the sync engine can serialize without linking the apply engine.
+inline std::string serializeChangeset(const SyncChangeset& changeset) {
+    std::string out = "{";
+    bool firstTable = true;
+    for (const auto& tablePair : changeset) {
+        const TableChangeset& tc = tablePair.second;
+        if (tc.upserted.empty() && tc.deleted.empty()) {
+            continue;
+        }
+        if (!firstTable) {
+            out += ",";
+        }
+        firstTable = false;
+        out += "\"" + json_utils::escapeJsonString(tablePair.first) + "\":{\"upserted\":[";
+        for (size_t i = 0; i < tc.upserted.size(); i++) {
+            if (i) out += ",";
+            out += "\"" + json_utils::escapeJsonString(tc.upserted[i]) + "\"";
+        }
+        out += "],\"deleted\":[";
+        for (size_t i = 0; i < tc.deleted.size(); i++) {
+            if (i) out += ",";
+            out += "\"" + json_utils::escapeJsonString(tc.deleted[i]) + "\"";
+        }
+        out += "]}";
+    }
+    out += "}";
+    return out;
+}
 
 } // namespace watermelondb

--- a/native/shared/SyncEngine.cpp
+++ b/native/shared/SyncEngine.cpp
@@ -390,6 +390,7 @@ void SyncEngine::startWithCompletion(const std::string& reason, CompletionCallba
             if (!resumeFromAuth) {
                 currentRequestId_ = platform::generateRequestId();
                 currentPullUrl_ = pullEndpointUrl_;
+                accumulatedChangeset_.clear(); // MOBILE-6276: fresh sync starts a fresh changeset
             } else if (currentRequestId_.empty()) {
                 currentRequestId_ = platform::generateRequestId();
             }
@@ -745,9 +746,10 @@ void SyncEngine::handleHttpResponse(int64_t syncId, const platform::HttpResponse
         response.statusCode == 304 ? std::string("{\"items\":[]}") : response.body;
 
     std::string applyError;
+    SyncChangeset pageChangeset;
 
     if (applyCb) {
-        if (!applyCb(pullBody, applyError)) {
+        if (!applyCb(pullBody, applyError, pageChangeset)) {
             CompletionCallback completionToCall;
             CompletionCallback pendingToCall;
             {
@@ -773,6 +775,18 @@ void SyncEngine::handleHttpResponse(int64_t syncId, const platform::HttpResponse
                 pendingToCall(false, applyError);
             }
             return;
+        }
+        // MOBILE-6276: fold this committed page's ids into the sync-wide accumulator (pages are
+        // applied sequentially; guard on syncId so a superseded sync can't contaminate a new one).
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (syncId == syncId_) {
+                for (auto& kv : pageChangeset) {
+                    auto& dst = accumulatedChangeset_[kv.first];
+                    dst.upserted.insert(dst.upserted.end(), kv.second.upserted.begin(), kv.second.upserted.end());
+                    dst.deleted.insert(dst.deleted.end(), kv.second.deleted.begin(), kv.second.deleted.end());
+                }
+            }
         }
     }
 
@@ -915,6 +929,13 @@ void SyncEngine::handleHttpResponse(int64_t syncId, const platform::HttpResponse
             start(pendingReason);
         }
     }
+}
+
+std::string SyncEngine::takeAccumulatedChangesetJson() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::string json = serializeChangeset(accumulatedChangeset_);
+    accumulatedChangeset_.clear();
+    return json;
 }
 
 bool SyncEngine::scheduleRetryLocked(int64_t syncId, int statusCode, const std::string& message) {

--- a/native/shared/SyncEngine.h
+++ b/native/shared/SyncEngine.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "SyncPlatform.h"
+#include "SyncApplyEngine.h"
 
 #include <functional>
 #include <memory>
@@ -12,7 +13,10 @@ namespace watermelondb {
 class SyncEngine : public std::enable_shared_from_this<SyncEngine> {
 public:
     using EventCallback = std::function<void(const std::string&)>;
-    using ApplyCallback = std::function<bool(const std::string& payload, std::string& errorMessage)>;
+    // MOBILE-6276: the apply callback appends the ids it committed into `changeset` so the engine
+    // can accumulate them across paginated pages and hand the total to JS at completion.
+    using ApplyCallback = std::function<bool(const std::string& payload, std::string& errorMessage,
+                                             SyncChangeset& changeset)>;
     using AuthTokenRequestCallback = std::function<void()>;
     using PushChangesCallback = std::function<void(std::function<void(bool success, const std::string& errorMessage)>)>;
     using CompletionCallback = std::function<void(bool success, const std::string& errorMessage)>;
@@ -33,6 +37,9 @@ public:
     void startWithCompletion(const std::string& reason, CompletionCallback completion);
     void cancelSync();
     std::string stateJson() const;
+    // MOBILE-6276: serialize + clear the changeset accumulated across this sync's pulled pages
+    // (JSON: {"<table>":{"upserted":[...],"deleted":[...]}}). Call once, from the pull completion.
+    std::string takeAccumulatedChangesetJson();
     void shutdown();
 
 private:
@@ -60,6 +67,7 @@ private:
     int maxAuthRetries_ = 3;
     int64_t syncId_ = 0;
     std::string pendingReason_;
+    SyncChangeset accumulatedChangeset_; // MOBILE-6276: guarded by mutex_
     CompletionCallback completionCallback_;
     CompletionCallback pendingCompletionCallback_;
     std::string currentReason_;

--- a/native/shared/tests/SyncApplyEngineTests.cpp
+++ b/native/shared/tests/SyncApplyEngineTests.cpp
@@ -413,7 +413,7 @@ void test_synced_record_full_overwrite() {
     execSql(db, "CREATE TABLE tasks (id TEXT PRIMARY KEY, name TEXT, _status TEXT, _changed TEXT)", error);
 
     // Insert a synced record (no local changes)
-    execSql(db, "INSERT INTO tasks (id, name, _status, _changed) VALUES ('t1', 'old-name', NULL, '')", error);
+    execSql(db, "INSERT INTO tasks (id, name, _status, _changed) VALUES ('t1', 'old-name', 'synced', '')", error);
 
     // Server sends updated values
     std::string payload = R"({
@@ -430,6 +430,47 @@ void test_synced_record_full_overwrite() {
     std::string name;
     expectTrue(querySingleText(db, "SELECT name FROM tasks WHERE id='t1'", name), "row should exist");
     expectTrue(name == "new-name", "synced record should be fully overwritten");
+
+    // MOBILE-6276: the full-overwrite must keep _status='synced'/_changed='' to match the
+    // legacy JS prepareCreateFromRaw path. Server rows carry no _status, so a plain
+    // INSERT OR REPLACE leaves _status NULL — and the app's pervasive `_status != 'deleted'`
+    // raw-SQL filters silently drop the row (NULL != 'deleted' is not TRUE in SQLite).
+    std::string status;
+    expectTrue(querySingleText(db, "SELECT _status FROM tasks WHERE id='t1'", status), "_status column should be readable");
+    expectTrue(status == "synced", "overwritten synced record must have _status='synced', not NULL");
+    expectTrue(querySingleInt(db, "SELECT _changed IS NULL FROM tasks WHERE id='t1'") == 0,
+               "overwritten synced record must have _changed='', not NULL");
+
+    sqlite3_close(db);
+}
+
+void test_new_record_pull_gets_synced_status() {
+    // MOBILE-6276: a brand-new row delivered by a native pull (a record created on another
+    // device, or the server echo of a locally-created record) must land with _status='synced'.
+    // Otherwise it is invisible to the app's `_status != 'deleted'` counts (e.g. the visit
+    // "Purchase orders — N Added" checklist, useVisitReportDetails.ts) → silent undercount.
+    sqlite3* db = nullptr;
+    sqlite3_open(":memory:", &db);
+    std::string error;
+    execSql(db, "CREATE TABLE purchase_orders (id TEXT PRIMARY KEY, po_number TEXT, status TEXT, _status TEXT, _changed TEXT)", error);
+
+    std::string payload = R"({
+        "count": 1,
+        "items": [
+          { "_table": "purchase_orders", "row": { "id": "fc05b880", "po_number": "9311", "status": "Fulfilled" } }
+        ]
+      })";
+
+    bool ok = watermelondb::applySyncPayload(db, payload, error);
+    expectTrue(ok, "applySyncPayload should succeed for a fresh pulled row");
+
+    std::string status;
+    expectTrue(querySingleText(db, "SELECT _status FROM purchase_orders WHERE id='fc05b880'", status), "pulled row should exist");
+    expectTrue(status == "synced", "freshly-pulled row must have _status='synced', not NULL (MOBILE-6276)");
+
+    // Direct reproduction of Symptom B: the count filter must include the pulled row.
+    expectTrue(querySingleInt(db, "SELECT COUNT(*) FROM purchase_orders WHERE _status != 'deleted'") == 1,
+               "`_status != 'deleted'` must count the pulled row (returns 0 when _status is NULL)");
 
     sqlite3_close(db);
 }
@@ -589,17 +630,13 @@ void test_server_payload_with_status_fields_does_not_corrupt() {
     expectTrue(querySingleText(db, "SELECT name FROM tasks WHERE id='t1'", name), "row should exist");
     expectTrue(name == "new-name", "name should be updated from server");
 
-    // _status should NOT be corrupted by server payload — INSERT OR REPLACE will set it,
-    // but the next sync cycle's markAsSynced will clean it up. The key thing is we
-    // don't accidentally turn a synced record into a 'created' one that blocks future pulls.
-    // Note: INSERT OR REPLACE does include _status from payload since it's a valid column.
-    // This test documents the current behavior for awareness.
+    // MOBILE-6276: server-supplied _status/_changed must be IGNORED. The native apply skips
+    // them from the payload and forces _status='synced'/_changed='' on the full-overwrite path,
+    // so a stray server _status:'created' can neither turn a synced record into a 'created' one
+    // (which would block future pulls) nor leave the row with _status=NULL.
     std::string status;
-    bool hasStatus = querySingleText(db, "SELECT _status FROM tasks WHERE id='t1'", status);
-    if (hasStatus) {
-        // Document what actually happens: INSERT OR REPLACE writes all columns including _status
-        expectTrue(true, "server _status was written (expected with INSERT OR REPLACE)");
-    }
+    expectTrue(querySingleText(db, "SELECT _status FROM tasks WHERE id='t1'", status), "_status should exist");
+    expectTrue(status == "synced", "server-supplied _status must be ignored and forced to 'synced'");
 
     // For a dirty (updated) record, _status/_changed from server should be excluded
     execSql(db, "DELETE FROM tasks", error);
@@ -630,6 +667,80 @@ void test_server_payload_with_status_fields_does_not_corrupt() {
     sqlite3_close(db);
 }
 
+void test_changeset_reports_upsert_delete_and_excludes_dirty() {
+    // MOBILE-6276: the engine reports exactly what it wrote — an upsert + a hard-delete — and
+    // EXCLUDES a locally-dirty ('created') row it skipped, so JS never refreshes a pending edit.
+    sqlite3* db = nullptr;
+    sqlite3_open(":memory:", &db);
+    std::string error;
+    execSql(db, "CREATE TABLE tasks (id TEXT PRIMARY KEY, name TEXT, _status TEXT, _changed TEXT)", error);
+    execSql(db, "INSERT INTO tasks (id, name, _status, _changed) VALUES ('dirty1','local','created','')", error);
+    execSql(db, "INSERT INTO tasks (id, name, _status, _changed) VALUES ('del1','gone','synced','')", error);
+
+    std::string payload = R"({
+        "items": [
+          { "_table": "tasks", "row": { "id": "up1", "name": "alpha" } },
+          { "_table": "tasks", "row": { "id": "dirty1", "name": "server" } },
+          { "_table": "tasks", "_deleted": true, "id": "del1" }
+        ]
+      })";
+
+    watermelondb::SyncChangeset cs;
+    bool ok = watermelondb::applySyncPayload(db, payload, error, cs);
+    expectTrue(ok, "apply should succeed");
+    expectTrue(watermelondb::serializeChangeset(cs) == R"({"tasks":{"upserted":["up1"],"deleted":["del1"]}})",
+               "changeset must list only written upserts + hard-deletes, excluding skipped dirty rows");
+
+    std::string name;
+    querySingleText(db, "SELECT name FROM tasks WHERE id='dirty1'", name);
+    expectTrue(name == "local", "locally-created row must be preserved (and excluded from changeset)");
+
+    sqlite3_close(db);
+}
+
+void test_changeset_includes_partial_merged_record() {
+    // A locally-'updated' row gets server columns merged in (applyPartialUpdate) — that IS a write,
+    // so its id must be reported as upserted while the locally-changed column is preserved.
+    sqlite3* db = nullptr;
+    sqlite3_open(":memory:", &db);
+    std::string error;
+    execSql(db, "CREATE TABLE tasks (id TEXT PRIMARY KEY, name TEXT, description TEXT, _status TEXT, _changed TEXT)", error);
+    execSql(db, "INSERT INTO tasks (id, name, description, _status, _changed) "
+                "VALUES ('m1','local','olddesc','updated','name')", error);
+
+    std::string payload = R"({
+        "items": [
+          { "_table": "tasks", "row": { "id": "m1", "name": "server", "description": "newdesc" } }
+        ]
+      })";
+
+    watermelondb::SyncChangeset cs;
+    bool ok = watermelondb::applySyncPayload(db, payload, error, cs);
+    expectTrue(ok, "partial-merge apply should succeed");
+    expectTrue(watermelondb::serializeChangeset(cs) == R"({"tasks":{"upserted":["m1"],"deleted":[]}})",
+               "partial-merged record id must be reported as upserted");
+
+    std::string name;
+    querySingleText(db, "SELECT name FROM tasks WHERE id='m1'", name);
+    expectTrue(name == "local", "locally-changed 'name' must be preserved through the merge");
+
+    sqlite3_close(db);
+}
+
+void test_empty_pull_changeset_is_empty_object() {
+    sqlite3* db = nullptr;
+    sqlite3_open(":memory:", &db);
+    std::string error;
+    execSql(db, "CREATE TABLE tasks (id TEXT PRIMARY KEY, name TEXT)", error);
+
+    watermelondb::SyncChangeset cs;
+    bool ok = watermelondb::applySyncPayload(db, "{\"items\":[]}", error, cs);
+    expectTrue(ok, "empty pull apply should succeed");
+    expectTrue(watermelondb::serializeChangeset(cs) == "{}", "empty pull must serialize to {}");
+
+    sqlite3_close(db);
+}
+
 } // namespace
 
 int main() {
@@ -649,11 +760,15 @@ int main() {
     test_created_record_not_overwritten();
     test_updated_record_partial_merge();
     test_synced_record_full_overwrite();
+    test_new_record_pull_gets_synced_status();
     test_deleted_record_not_overwritten();
     test_updated_record_all_changed_skips_update();
     test_mixed_dirty_and_synced_records();
     test_table_without_status_columns();
     test_server_payload_with_status_fields_does_not_corrupt();
+    test_changeset_reports_upsert_delete_and_excludes_dirty();
+    test_changeset_includes_partial_merged_record();
+    test_empty_pull_changeset_is_empty_object();
 
     if (gFailures > 0) {
         std::cerr << gFailures << " test(s) failed\n";

--- a/native/shared/tests/SyncEngineTests.cpp
+++ b/native/shared/tests/SyncEngineTests.cpp
@@ -87,7 +87,7 @@ void test_success_flow() {
     EventRecorder recorder;
     auto engine = std::make_shared<watermelondb::SyncEngine>();
     engine->setEventCallback([&](const std::string& eventJson) { recorder.add(eventJson); });
-    engine->setApplyCallback([&](const std::string&, std::string&) { return true; });
+    engine->setApplyCallback([&](const std::string&, std::string&, watermelondb::SyncChangeset&) { return true; });
     engine->setPushChangesCallback([&](std::function<void(bool, const std::string&)> completion) {
         completion(true, "");
     });
@@ -110,7 +110,7 @@ void test_auth_required() {
     EventRecorder recorder;
     auto engine = std::make_shared<watermelondb::SyncEngine>();
     engine->setEventCallback([&](const std::string& eventJson) { recorder.add(eventJson); });
-    engine->setApplyCallback([&](const std::string&, std::string&) { return true; });
+    engine->setApplyCallback([&](const std::string&, std::string&, watermelondb::SyncChangeset&) { return true; });
 
     watermelondb::platform::setHttpHandler([](const watermelondb::platform::HttpRequest&,
                                               std::function<void(const watermelondb::platform::HttpResponse&)> done) {
@@ -129,7 +129,7 @@ void test_retry_flow() {
     EventRecorder recorder;
     auto engine = std::make_shared<watermelondb::SyncEngine>();
     engine->setEventCallback([&](const std::string& eventJson) { recorder.add(eventJson); });
-    engine->setApplyCallback([&](const std::string&, std::string&) { return true; });
+    engine->setApplyCallback([&](const std::string&, std::string&, watermelondb::SyncChangeset&) { return true; });
     engine->setPushChangesCallback([&](std::function<void(bool, const std::string&)> completion) {
         completion(true, "");
     });
@@ -173,7 +173,7 @@ void test_cursor_pagination() {
     EventRecorder recorder;
     auto engine = std::make_shared<watermelondb::SyncEngine>();
     engine->setEventCallback([&](const std::string& eventJson) { recorder.add(eventJson); });
-    engine->setApplyCallback([&](const std::string&, std::string&) { return true; });
+    engine->setApplyCallback([&](const std::string&, std::string&, watermelondb::SyncChangeset&) { return true; });
     engine->setPushChangesCallback([&](std::function<void(bool, const std::string&)> completion) {
         completion(true, "");
     });
@@ -204,11 +204,67 @@ void test_cursor_pagination() {
     expectTrue(recorder.waitForContains("\"state\":\"done\""), "expected done after pagination");
 }
 
+void test_changeset_accumulates_across_pages() {
+    // MOBILE-6276: the engine must merge EACH pulled page's changeset and hand the total to the
+    // completion consumer via takeAccumulatedChangesetJson() — not just the last page's.
+    auto engine = std::make_shared<watermelondb::SyncEngine>();
+
+    std::mutex applyMutex;
+    int applyPage = 0;
+    engine->setApplyCallback([&](const std::string&, std::string&, watermelondb::SyncChangeset& changeset) {
+        std::lock_guard<std::mutex> lock(applyMutex);
+        changeset["tasks"].upserted.push_back(applyPage == 0 ? "page0" : "page1");
+        applyPage++;
+        return true;
+    });
+    engine->setPushChangesCallback([&](std::function<void(bool, const std::string&)> completion) {
+        completion(true, "");
+    });
+
+    static int callCount = 0;
+    callCount = 0;
+    watermelondb::platform::setHttpHandler([](const watermelondb::platform::HttpRequest&,
+                                              std::function<void(const watermelondb::platform::HttpResponse&)> done) {
+        watermelondb::platform::HttpResponse response;
+        response.statusCode = 200;
+        response.body = (callCount == 0) ? "{\"changes\":{},\"next\":{\"c\":1}}"
+                                         : "{\"changes\":{},\"next\":null}";
+        callCount++;
+        done(response);
+    });
+
+    std::mutex m;
+    std::condition_variable cv;
+    bool completed = false;
+    std::string capturedJson;
+    engine->configure("{\"pullEndpointUrl\":\"https://example.com/pull\",\"connectionTag\":1}");
+    engine->startWithCompletion("accumulate", [&](bool, const std::string&) {
+        // Read exactly as the native bridge will — synchronously in the completion body.
+        capturedJson = engine->takeAccumulatedChangesetJson();
+        {
+            std::lock_guard<std::mutex> lock(m);
+            completed = true;
+        }
+        cv.notify_all();
+    });
+
+    {
+        std::unique_lock<std::mutex> lock(m);
+        cv.wait_for(lock, std::chrono::milliseconds(500), [&] { return completed; });
+    }
+    expectTrue(completed, "accumulate sync should complete");
+    expectTrue(capturedJson == R"({"tasks":{"upserted":["page0","page1"],"deleted":[]}})",
+               "changeset must accumulate ids from BOTH pages, not just the last");
+    expectTrue(engine->takeAccumulatedChangesetJson() == "{}", "take clears the accumulator");
+
+    watermelondb::platform::setHttpHandler(nullptr);
+}
+
 void test_auth_required_resumes_cursor() {
     EventRecorder recorder;
     auto engine = std::make_shared<watermelondb::SyncEngine>();
     engine->setEventCallback([&](const std::string& eventJson) { recorder.add(eventJson); });
-    engine->setApplyCallback([&](const std::string&, std::string&) { return true; });
+    engine->setApplyCallback([&](const std::string&, std::string&, watermelondb::SyncChangeset&) { return true; });
 
     engine->setAuthTokenRequestCallback([engine]() { engine->setAuthToken("token-2"); });
     engine->setAuthToken("token-1");
@@ -259,7 +315,7 @@ void test_shutdown_prevents_events() {
     EventRecorder recorder;
     auto engine = std::make_shared<watermelondb::SyncEngine>();
     engine->setEventCallback([&](const std::string& eventJson) { recorder.add(eventJson); });
-    engine->setApplyCallback([&](const std::string&, std::string&) { return true; });
+    engine->setApplyCallback([&](const std::string&, std::string&, watermelondb::SyncChangeset&) { return true; });
 
     watermelondb::platform::setHttpHandler([](const watermelondb::platform::HttpRequest&,
                                               std::function<void(const watermelondb::platform::HttpResponse&)> done) {
@@ -280,7 +336,7 @@ void test_auth_token_restart() {
     EventRecorder recorder;
     auto engine = std::make_shared<watermelondb::SyncEngine>();
     engine->setEventCallback([&](const std::string& eventJson) { recorder.add(eventJson); });
-    engine->setApplyCallback([&](const std::string&, std::string&) { return true; });
+    engine->setApplyCallback([&](const std::string&, std::string&, watermelondb::SyncChangeset&) { return true; });
 
     watermelondb::platform::setHttpHandler([](const watermelondb::platform::HttpRequest&,
                                               std::function<void(const watermelondb::platform::HttpResponse&)> done) {
@@ -309,7 +365,7 @@ void test_completion_preserved_after_auth_refresh() {
     EventRecorder recorder;
     auto engine = std::make_shared<watermelondb::SyncEngine>();
     engine->setEventCallback([&](const std::string& eventJson) { recorder.add(eventJson); });
-    engine->setApplyCallback([&](const std::string&, std::string&) { return true; });
+    engine->setApplyCallback([&](const std::string&, std::string&, watermelondb::SyncChangeset&) { return true; });
 
     std::mutex completionMutex;
     std::condition_variable completionCv;
@@ -357,7 +413,7 @@ void test_queue_when_in_flight() {
     EventRecorder recorder;
     auto engine = std::make_shared<watermelondb::SyncEngine>();
     engine->setEventCallback([&](const std::string& eventJson) { recorder.add(eventJson); });
-    engine->setApplyCallback([&](const std::string&, std::string&) { return true; });
+    engine->setApplyCallback([&](const std::string&, std::string&, watermelondb::SyncChangeset&) { return true; });
     std::function<void(bool, const std::string&)> pushCompletion;
     engine->setPushChangesCallback([&](std::function<void(bool, const std::string&)> completion) {
         pushCompletion = std::move(completion);
@@ -386,7 +442,7 @@ void test_backoff_delay_cap() {
     EventRecorder recorder;
     auto engine = std::make_shared<watermelondb::SyncEngine>();
     engine->setEventCallback([&](const std::string& eventJson) { recorder.add(eventJson); });
-    engine->setApplyCallback([&](const std::string&, std::string&) { return true; });
+    engine->setApplyCallback([&](const std::string&, std::string&, watermelondb::SyncChangeset&) { return true; });
 
     watermelondb::platform::setHttpHandler([](const watermelondb::platform::HttpRequest&,
                                               std::function<void(const watermelondb::platform::HttpResponse&)> done) {
@@ -407,7 +463,7 @@ void test_missing_endpoint_error() {
     EventRecorder recorder;
     auto engine = std::make_shared<watermelondb::SyncEngine>();
     engine->setEventCallback([&](const std::string& eventJson) { recorder.add(eventJson); });
-    engine->setApplyCallback([&](const std::string&, std::string&) { return true; });
+    engine->setApplyCallback([&](const std::string&, std::string&, watermelondb::SyncChangeset&) { return true; });
 
     watermelondb::platform::setHttpHandler(nullptr);
 
@@ -423,7 +479,7 @@ void test_invalid_config_json() {
     EventRecorder recorder;
     auto engine = std::make_shared<watermelondb::SyncEngine>();
     engine->setEventCallback([&](const std::string& eventJson) { recorder.add(eventJson); });
-    engine->setApplyCallback([&](const std::string&, std::string&) { return true; });
+    engine->setApplyCallback([&](const std::string&, std::string&, watermelondb::SyncChangeset&) { return true; });
 
     watermelondb::platform::setHttpHandler(nullptr);
 
@@ -439,7 +495,7 @@ void test_apply_error_sets_state() {
     EventRecorder recorder;
     auto engine = std::make_shared<watermelondb::SyncEngine>();
     engine->setEventCallback([&](const std::string& eventJson) { recorder.add(eventJson); });
-    engine->setApplyCallback([&](const std::string&, std::string& errorMessage) {
+    engine->setApplyCallback([&](const std::string&, std::string& errorMessage, watermelondb::SyncChangeset&) {
         errorMessage = "apply failed";
         return false;
     });
@@ -476,7 +532,7 @@ void test_not_modified_304_is_noop_success() {
     std::mutex applyMutex;
     int applyCount = 0;
     std::string appliedBody;
-    engine->setApplyCallback([&](const std::string& body, std::string& errorMessage) {
+    engine->setApplyCallback([&](const std::string& body, std::string& errorMessage, watermelondb::SyncChangeset&) {
         {
             std::lock_guard<std::mutex> lock(applyMutex);
             applyCount++;
@@ -555,7 +611,7 @@ void test_cancel_sync_in_flight() {
     EventRecorder recorder;
     auto engine = std::make_shared<watermelondb::SyncEngine>();
     engine->setEventCallback([&](const std::string& eventJson) { recorder.add(eventJson); });
-    engine->setApplyCallback([&](const std::string&, std::string&) { return true; });
+    engine->setApplyCallback([&](const std::string&, std::string&, watermelondb::SyncChangeset&) { return true; });
 
     // Hold sync in push phase so we can cancel it
     engine->setPushChangesCallback([&](std::function<void(bool, const std::string&)> cb) {
@@ -611,7 +667,7 @@ void test_cancel_sync_during_auth_required() {
     EventRecorder recorder;
     auto engine = std::make_shared<watermelondb::SyncEngine>();
     engine->setEventCallback([&](const std::string& eventJson) { recorder.add(eventJson); });
-    engine->setApplyCallback([&](const std::string&, std::string&) { return true; });
+    engine->setApplyCallback([&](const std::string&, std::string&, watermelondb::SyncChangeset&) { return true; });
     engine->setAuthTokenRequestCallback([]() {
         // Don't provide a token — simulates JS auth provider not responding yet
     });
@@ -672,7 +728,7 @@ void test_cancel_sync_fires_pending_completion() {
     EventRecorder recorder;
     auto engine = std::make_shared<watermelondb::SyncEngine>();
     engine->setEventCallback([&](const std::string& eventJson) { recorder.add(eventJson); });
-    engine->setApplyCallback([&](const std::string&, std::string&) { return true; });
+    engine->setApplyCallback([&](const std::string&, std::string&, watermelondb::SyncChangeset&) { return true; });
 
     // Hold sync in push phase
     engine->setPushChangesCallback([&](std::function<void(bool, const std::string&)> cb) {
@@ -746,7 +802,7 @@ void test_cancel_restores_push_callback_via_completion() {
     EventRecorder recorder;
     auto engine = std::make_shared<watermelondb::SyncEngine>();
     engine->setEventCallback([&](const std::string& eventJson) { recorder.add(eventJson); });
-    engine->setApplyCallback([&](const std::string&, std::string&) { return true; });
+    engine->setApplyCallback([&](const std::string&, std::string&, watermelondb::SyncChangeset&) { return true; });
 
     engine->setPushChangesCallback([&](std::function<void(bool, const std::string&)> completion) {
         realPushCalled = true;
@@ -808,7 +864,7 @@ void test_foreground_overrides_background_sync() {
     EventRecorder recorder;
     auto engine = std::make_shared<watermelondb::SyncEngine>();
     engine->setEventCallback([&](const std::string& eventJson) { recorder.add(eventJson); });
-    engine->setApplyCallback([&](const std::string&, std::string&) { return true; });
+    engine->setApplyCallback([&](const std::string&, std::string&, watermelondb::SyncChangeset&) { return true; });
 
     auto realPush = [&](std::function<void(bool, const std::string&)> cb) {
         realPushCalled = true;
@@ -909,7 +965,7 @@ void test_cancel_during_http_allows_new_sync() {
     EventRecorder recorder;
     auto engine = std::make_shared<watermelondb::SyncEngine>();
     engine->setEventCallback([&](const std::string& eventJson) { recorder.add(eventJson); });
-    engine->setApplyCallback([&](const std::string&, std::string&) { return true; });
+    engine->setApplyCallback([&](const std::string&, std::string&, watermelondb::SyncChangeset&) { return true; });
     engine->setPushChangesCallback([](std::function<void(bool, const std::string&)> cb) { cb(true, ""); });
 
     std::function<void(const watermelondb::platform::HttpResponse&)> firstHttpDone;
@@ -961,7 +1017,7 @@ void test_rapid_cancel_and_restart() {
     EventRecorder recorder;
     auto engine = std::make_shared<watermelondb::SyncEngine>();
     engine->setEventCallback([&](const std::string& eventJson) { recorder.add(eventJson); });
-    engine->setApplyCallback([&](const std::string&, std::string&) { return true; });
+    engine->setApplyCallback([&](const std::string&, std::string&, watermelondb::SyncChangeset&) { return true; });
     engine->setPushChangesCallback([](std::function<void(bool, const std::string&)> cb) { cb(true, ""); });
 
     // Hold HTTP responses so sync is genuinely in-flight when cancelSync() runs.
@@ -1065,6 +1121,7 @@ int main() {
     test_auth_required();
     test_retry_flow();
     test_cursor_pagination();
+    test_changeset_accumulates_across_pages();
     test_auth_required_resumes_cursor();
     test_shutdown_prevents_events();
     test_auth_token_restart();

--- a/native/specs/NativeWatermelonDBModule.ts
+++ b/native/specs/NativeWatermelonDBModule.ts
@@ -10,7 +10,8 @@ export interface Spec extends TurboModule {
   ): Promise<void>
   configureSync(configJson: string): void
   startSync(reason: string): void
-  syncDatabaseAsync(reason: string): Promise<void>
+  // Resolves the JSON changeset the pull applied ({ "<table>": { "upserted": [...], "deleted": [...] } }).
+  syncDatabaseAsync(reason: string): Promise<string>
   setSyncPullUrl(pullEndpointUrl: string): void
   getSyncStateJson(): string
   addSyncListener(listener: (eventJson: string) => void): number

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "7.0.4-23",
+  "version": "7.0.4-31",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/src/Database/index.ts
+++ b/src/Database/index.ts
@@ -2,7 +2,7 @@ import { values } from 'rambdax'
 
 import { Observable, startWith, merge as merge$ } from '../utils/rx'
 import { Unsubscribe } from '../utils/subscriptions'
-import { invariant } from '../utils/common'
+import { invariant, logError } from '../utils/common'
 import { noop } from '../utils/fp'
 import { toPromise } from '../utils/fp/Result'
 
@@ -13,9 +13,16 @@ import type Collection from '../Collection'
 import type { CollectionChangeSet } from '../Collection'
 import { CollectionChangeTypes } from '../Collection/common'
 import type { TableName, AppSchema } from '../Schema'
+import * as Q from '../QueryDescription'
 
 import CollectionMap from './CollectionMap'
 import ActionQueue, { ActionInterface } from './ActionQueue'
+
+// MOBILE-6276: the changeset the native (Nitro) sync engine reports for a pull — the exact set of
+// record ids it wrote (upserted: created/updated/partial-merged) or hard-deleted, per table.
+export type NativePullChangeSet = {
+  [table: string]: { upserted?: string[]; deleted?: string[] }
+}
 
 // Lazy-loaded event emitter to avoid circular dependencies
 let _eventEmitter: any = null
@@ -89,6 +96,83 @@ export default class Database {
     })
 
     this.notify(tables)
+  }
+
+  // MOBILE-6276: apply the changeset the native (Nitro) sync engine reports for a pull. `changeSet`
+  // maps table -> { upserted, deleted } record ids the native apply actually wrote / removed (native
+  // computes this exactly; JS never guesses). Two concerns, kept separate on purpose:
+  //
+  //   1. Refresh already-cached instances in place so record-level observers (findAndObserve /
+  //      model.observe / relations) see fresh data:
+  //        - cached upserts: re-read via _modelForRaw (updates _raw in place + fires _notifyChanged).
+  //          Only records already in the JS cache are re-read — bounded by cache size, not pull size,
+  //          so a large pull can't mass-load every row into memory.
+  //        - cached deletes: evict from the cache + _notifyDestroyed the instance.
+  //   2. Wake EVERY changed table's query observers with the empty-changeset (full-refetch) signal,
+  //      so simple AND reloading observers re-query SQLite and correctly reflect inserts/updates/
+  //      deletes — including rows never cached in JS. We deliberately never hand query observers a
+  //      partial changeset: subscribeToSimpleQuery applies a non-empty changeset INCREMENTALLY and
+  //      would miss an uncached newly-inserted row on a table that also had cached changes.
+  //
+  // No size cap is needed. The in-place refresh relies on native CDC returning full records (the
+  // Nitro path enables it before syncing); without CDC the re-read yields ids and cannot refresh —
+  // warn rather than fail silently.
+  applyNativePullChanges = async (changeSet: NativePullChangeSet): Promise<void> => {
+    const CHUNK = 900 // stay under SQLite's ~999 bound-variable limit
+    const changedTables: TableName<any>[] = []
+    let hasCachedUpserts = false
+    for (const table of Object.keys(changeSet)) {
+      const collection = this.collections.get(table as TableName<any>)
+      if (!collection) {
+        continue
+      }
+      changedTables.push(table as TableName<any>)
+      // Best-effort in-place refresh of already-cached instances (reaches findAndObserve). A failure
+      // here MUST NOT abort the loop or skip the query-observer wake below — that wake re-queries
+      // SQLite (the source of truth) and is the load-bearing refresh — so isolate it per table.
+      try {
+        const upserted = changeSet[table].upserted ?? []
+        const deleted = changeSet[table].deleted ?? []
+        // Refresh only upserted records already in the cache (memory-safe; uncached rows are picked
+        // up lazily by the query-observer refetch below).
+        const cachedUpsertedIds = upserted.filter((id) => collection._cache.map.has(id))
+        if (cachedUpsertedIds.length > 0) {
+          hasCachedUpserts = true
+        }
+        for (let i = 0; i < cachedUpsertedIds.length; i += CHUNK) {
+          const chunk = cachedUpsertedIds.slice(i, i + CHUNK)
+          // eslint-disable-next-line no-await-in-loop
+          await collection.query(Q.where('id', Q.oneOf(chunk))).fetch()
+        }
+        // Destroy cached deletes directly (evict + notify the record), so we never emit a partial
+        // collection changeset. Query observers learn of the deletion via the full-refetch wake below.
+        for (const id of deleted) {
+          const record = collection._cache.get(id)
+          if (record) {
+            collection._cache.delete(record)
+            record._notifyDestroyed()
+          }
+        }
+      } catch (error) {
+        logError(
+          `[WatermelonDB] applyNativePullChanges: in-place refresh failed for table ${table}: ${String(
+            error,
+          )}. Query observers are still woken below and reconcile from SQLite.`,
+        )
+      }
+    }
+    if (hasCachedUpserts && !this._nativeCDCEnabled) {
+      logError(
+        '[WatermelonDB] applyNativePullChanges refreshed cached records while native CDC is disabled; ' +
+          'the in-place _raw refresh needs CDC (full-record reads) and may be a no-op.',
+      )
+    }
+    // Full-refetch wake for every changed table (empty changeset → simple + reloading observers
+    // re-query SQLite). Runs even if an in-place refresh above threw, so a successful sync never
+    // leaves lists/counts stale. Never a partial changeset, so no observer can miss an uncached row.
+    if (changedTables.length > 0) {
+      this.notify(changedTables)
+    }
   }
 
   _cdcSubscription: { remove: () => void } | null = null

--- a/src/Database/notify.test.js
+++ b/src/Database/notify.test.js
@@ -986,3 +986,148 @@ describe('database.notify()', () => {
     })
   })
 })
+
+describe('database.applyNativePullChanges()', () => {
+  it('refreshes an upserted cached record in place and notifies its observer (MOBILE-6276)', async () => {
+    const { database, tasks } = mockDatabase({ actionsEnabled: true })
+    database._nativeCDCEnabled = true // the re-read returns full raws under CDC (see stub below)
+
+    const task = await database.action(() =>
+      tasks.create((t) => {
+        t.name = 'Original'
+        t._raw._status = 'synced'
+      }),
+    )
+
+    // Observe it the findAndObserve way: a single record, no live collection query on its table.
+    const emissions = []
+    const sub = task.observe().subscribe((t) => emissions.push(t.name))
+    expect(emissions).toEqual(['Original'])
+
+    // The native pull wrote a new value; because native CDC is on, the re-read returns a FULL RAW
+    // (not an id), which lets RecordCache._modelForRaw refresh the cached instance in place. (The
+    // LokiJS test adapter can't toggle CDC, so we stub the raw return the SQLite adapter produces.)
+    const serverRaw = { ...task._raw, name: 'ServerUpdated' }
+    jest
+      .spyOn(database.adapter.underlyingAdapter, 'query')
+      .mockImplementation((_query, cb) => cb({ value: [serverRaw] }))
+
+    await database.applyNativePullChanges({ mock_tasks: { upserted: [task.id] } })
+
+    expect(task.name).toBe('ServerUpdated')
+    expect(emissions[emissions.length - 1]).toBe('ServerUpdated')
+
+    sub.unsubscribe()
+  })
+
+  it('destroys a deleted cached record — evicts it, notifies it destroyed, wakes query observers (MOBILE-6276)', async () => {
+    const { database, tasks } = mockDatabase({ actionsEnabled: true })
+
+    const task = await database.action(() =>
+      tasks.create((t) => {
+        t.name = 'Doomed'
+        t._raw._status = 'synced'
+      }),
+    )
+    expect(tasks._cache.map.has(task.id)).toBe(true)
+
+    const destroyedSpy = jest.spyOn(task, '_notifyDestroyed')
+    const wake = jest.fn()
+    const unsub = tasks.experimentalSubscribe(wake)
+
+    await database.applyNativePullChanges({ mock_tasks: { deleted: [task.id] } })
+
+    // Evicted from cache + the record instance notified of destruction (reaches findAndObserve)...
+    expect(tasks._cache.map.has(task.id)).toBe(false)
+    expect(destroyedSpy).toHaveBeenCalled()
+    // ...and the table's query observers are woken (empty-changeset full refetch) so lists drop it.
+    expect(wake).toHaveBeenCalledWith([])
+
+    unsub()
+  })
+
+  it('does not hand query observers a partial changeset for a mixed cached+uncached upsert (MOBILE-6276)', async () => {
+    // Regression for the -27 bug: subscribeToSimpleQuery applies a NON-empty changeset incrementally
+    // and would miss an uncached newly-inserted row on a table that also had a cached change. The fix
+    // wakes query observers only with the empty (full-refetch) signal — never a partial changeset.
+    const { database, tasks } = mockDatabase({ actionsEnabled: true })
+    database._nativeCDCEnabled = true
+    const cached = await database.action(() =>
+      tasks.create((t) => {
+        t.name = 'Cached'
+        t._raw._status = 'synced'
+      }),
+    )
+    jest
+      .spyOn(database.adapter.underlyingAdapter, 'query')
+      .mockImplementation((_query, cb) => cb({ value: [{ ...cached._raw }] }))
+
+    const changesets = []
+    const sub = tasks.experimentalSubscribe((cs) => changesets.push(cs))
+
+    await database.applyNativePullChanges({ mock_tasks: { upserted: [cached.id, 'uncached-new'] } })
+
+    // The collection observer was woken only with empty changesets (full refetch), so a simple query
+    // observer re-queries SQLite and picks up the uncached new row — never an incomplete incremental set.
+    expect(changesets.length).toBeGreaterThan(0)
+    expect(changesets.every((cs) => cs.length === 0)).toBe(true)
+
+    sub()
+  })
+
+  it('does not materialize an uncached upserted record; wakes query observers instead (MOBILE-6276)', async () => {
+    // Memory safety: a large pull must not mass-load every upserted row into the JS cache. An
+    // upserted id that isn't already cached is left for a live query observer to materialize lazily.
+    const { database, tasks } = mockDatabase({ actionsEnabled: true })
+    expect(tasks._cache.map.size).toBe(0)
+
+    const querySpy = jest.spyOn(database.adapter.underlyingAdapter, 'query')
+    const wake = jest.fn()
+    const unsub = tasks.experimentalSubscribe(wake)
+
+    await database.applyNativePullChanges({ mock_tasks: { upserted: ['brand-new-id'] } })
+
+    // The uncached record was NOT force-read/materialized...
+    expect(querySpy).not.toHaveBeenCalled()
+    expect(tasks._cache.map.has('brand-new-id')).toBe(false)
+    // ...but the table's query observers were woken so a live query re-runs and picks it up.
+    expect(wake).toHaveBeenCalled()
+
+    unsub()
+  })
+
+  it('still wakes query observers when the in-place refresh throws (MOBILE-6276)', async () => {
+    // Robustness: a failed in-place re-read (adapter/DB error) must not abort the reconciliation —
+    // the query-observer wake (which re-reads SQLite) is the load-bearing refresh and must still fire,
+    // so a successful sync never silently leaves lists stale.
+    const { database, tasks } = mockDatabase({ actionsEnabled: true })
+    database._nativeCDCEnabled = true
+    const cached = await database.action(() =>
+      tasks.create((t) => {
+        t.name = 'C'
+        t._raw._status = 'synced'
+      }),
+    )
+    jest
+      .spyOn(database.adapter.underlyingAdapter, 'query')
+      .mockImplementation((_query, cb) => cb({ error: new Error('boom') }))
+    const wake = jest.fn()
+    const unsub = tasks.experimentalSubscribe(wake)
+
+    await expect(
+      database.applyNativePullChanges({ mock_tasks: { upserted: [cached.id] } }),
+    ).resolves.toBeUndefined()
+
+    // The in-place re-read threw and was swallowed, but query observers were still woken.
+    expect(wake).toHaveBeenCalledWith([])
+
+    unsub()
+  })
+
+  it('resolves without notifying on an empty changeset', async () => {
+    const { database } = mockDatabase({ actionsEnabled: true })
+    const notifySpy = jest.spyOn(database, 'notify')
+    await expect(database.applyNativePullChanges({})).resolves.toBeUndefined()
+    expect(notifySpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/sync/SyncManager.test.js
+++ b/src/sync/SyncManager.test.js
@@ -315,6 +315,121 @@ describe('SyncManager', () => {
     await expect(SyncManager.syncDatabaseAsync('manual')).rejects.toThrow('boom')
   })
 
+  it('applies the native changeset via applyNativePullChanges when the pull returns one (MOBILE-6276)', async () => {
+    const { SyncManager, nativeSync } = makeModule()
+    const notify = jest.fn()
+    const applyNativePullChanges = jest.fn(() => Promise.resolve())
+    const database = { schema: { tables: { purchase_orders: {}, visits: {} } }, notify, applyNativePullChanges }
+    SyncManager.configure({
+      database,
+      adapter: { _tag: 1 },
+      pushChangesProvider: jest.fn(),
+      pullChangesUrl: 'https://example.com/pull',
+    })
+
+    const changeSet = { purchase_orders: { upserted: ['po1'], deleted: [] } }
+    nativeSync.syncDatabaseAsync.mockResolvedValue(JSON.stringify({ changeset: changeSet, error: null }))
+
+    await SyncManager.syncDatabaseAsync('manual')
+    await flushMicrotasks()
+
+    // The precise changeset is applied through the record-level reconciliation path — no coarse fallback.
+    expect(applyNativePullChanges).toHaveBeenCalledWith(changeSet)
+    expect(notify).not.toHaveBeenCalled()
+  })
+
+  it('applies the pulled changeset then rejects when the envelope carries an error (push-fail) (MOBILE-6276)', async () => {
+    const { SyncManager, nativeSync } = makeModule()
+    const applyNativePullChanges = jest.fn(() => Promise.resolve())
+    const database = { schema: { tables: { purchase_orders: {} } }, notify: jest.fn(), applyNativePullChanges }
+    SyncManager.configure({
+      database,
+      adapter: { _tag: 1 },
+      pushChangesProvider: jest.fn(),
+      pullChangesUrl: 'https://example.com/pull',
+    })
+
+    // Pull succeeded (rows are in SQLite) but the push leg failed: native resolves the envelope with
+    // both the changeset AND the error. The pulled changes must refresh JS, THEN the sync rejects.
+    const changeSet = { purchase_orders: { upserted: ['po1'], deleted: [] } }
+    nativeSync.syncDatabaseAsync.mockResolvedValue(JSON.stringify({ changeset: changeSet, error: 'push failed' }))
+
+    await expect(SyncManager.syncDatabaseAsync('manual')).rejects.toThrow('push failed')
+    await flushMicrotasks()
+
+    // Refresh happened despite the failure — the pulled rows are not left JS-stale.
+    expect(applyNativePullChanges).toHaveBeenCalledWith(changeSet)
+  })
+
+  it('falls back to notify(allTables) when the native pull returns no changeset (MOBILE-6276)', async () => {
+    const { SyncManager } = makeModule()
+    const notify = jest.fn()
+    // No applyNativePullChanges + native resolves undefined (pre-changeset native) → coarse fallback.
+    const database = {
+      schema: { tables: { purchase_orders: {}, purchase_order_receipts: {}, visits: {} } },
+      notify,
+    }
+    SyncManager.configure({
+      database,
+      adapter: { _tag: 1 },
+      pushChangesProvider: jest.fn(),
+      pullChangesUrl: 'https://example.com/pull',
+    })
+
+    await SyncManager.syncDatabaseAsync('manual')
+    await flushMicrotasks()
+
+    expect(notify).toHaveBeenCalledTimes(1)
+    expect(notify).toHaveBeenCalledWith(['purchase_orders', 'purchase_order_receipts', 'visits'])
+  })
+
+  it('applies a large changeset via applyNativePullChanges without a size cap (MOBILE-6276)', async () => {
+    const { SyncManager, nativeSync } = makeModule()
+    const notify = jest.fn()
+    const applyNativePullChanges = jest.fn(() => Promise.resolve())
+    const database = { schema: { tables: { visits: {} } }, notify, applyNativePullChanges }
+    SyncManager.configure({
+      database,
+      adapter: { _tag: 1 },
+      pushChangesProvider: jest.fn(),
+      pullChangesUrl: 'https://example.com/pull',
+    })
+
+    // A large changeset is still applied precisely — applyNativePullChanges bounds its work by the
+    // JS cache size, so there is no id-count cap / coarse fallback for big pulls.
+    const bigIds = Array.from({ length: 6000 }, (_, i) => `id${i}`)
+    const changeSet = { visits: { upserted: bigIds } }
+    nativeSync.syncDatabaseAsync.mockResolvedValue(JSON.stringify({ changeset: changeSet, error: null }))
+
+    await SyncManager.syncDatabaseAsync('manual')
+    await flushMicrotasks()
+
+    expect(applyNativePullChanges).toHaveBeenCalledWith(changeSet)
+    expect(notify).not.toHaveBeenCalled()
+  })
+
+  it('does not notify or apply changes when the native pull hard-rejects (MOBILE-6276)', async () => {
+    // Native resolves the envelope on pull/push failure; it only rejects the promise on a hard
+    // pre-flight failure (e.g. runtime unavailable) — in which nothing was applied, so no refresh.
+    const { SyncManager, nativeSync } = makeModule()
+    const notify = jest.fn()
+    const applyNativePullChanges = jest.fn(() => Promise.resolve())
+    const database = { schema: { tables: { visits: {} } }, notify, applyNativePullChanges }
+    SyncManager.configure({
+      database,
+      adapter: { _tag: 1 },
+      pushChangesProvider: jest.fn(),
+      pullChangesUrl: 'https://example.com/pull',
+    })
+
+    nativeSync.syncDatabaseAsync.mockRejectedValue(new Error('boom'))
+    await expect(SyncManager.syncDatabaseAsync('manual')).rejects.toThrow('boom')
+    await flushMicrotasks()
+
+    expect(notify).not.toHaveBeenCalled()
+    expect(applyNativePullChanges).not.toHaveBeenCalled()
+  })
+
   it('cancelSync calls native cancelSync', () => {
     const { SyncManager, nativeSync } = makeModule()
     SyncManager.configure({

--- a/src/sync/SyncManager.ts
+++ b/src/sync/SyncManager.ts
@@ -1,4 +1,4 @@
-import type Database from '../Database'
+import type { default as Database, NativePullChangeSet } from '../Database'
 import { getLastPulledAt } from './impl'
 import {
   configureSync as nativeConfigureSync,
@@ -133,6 +133,75 @@ export class SyncManager {
     return SyncManager.refreshPullChangesUrlFromSequenceId()
       .catch(() => { })
       .then(() => nativeSyncDatabaseAsync(reason))
+      .then((resultJson) => SyncManager.applyNativePullResult(resultJson))
+  }
+
+  // MOBILE-6276: the native pull applies rows straight to SQLite, bypassing Database.batch, so the JS
+  // layer must be told what changed or it serves pre-sync values (stale UI until app restart). Native
+  // resolves an envelope { changeset: { table: { upserted, deleted } }, error: string | null } on
+  // EVERY outcome — success, a pull failure, or a push failure. Because the pulled rows are already
+  // committed to SQLite (and the cursor advanced) before the push runs, the changeset must refresh the
+  // JS layer even when the push leg fails and the sync ultimately rejects — otherwise those rows stay
+  // JS-stale until a later server change or app restart. So: apply the changeset first (through
+  // Database.applyNativePullChanges → the standard notify(changeSet) reconciliation), THEN rethrow any
+  // error so the caller still sees the failure. Falls back to a coarse notify(allTables) only when
+  // there is no usable changeset (a native build predating the envelope resolves undefined).
+  private static applyNativePullResult(resultJson: string | void): Promise<void> {
+    const { changeSet, error } = SyncManager.parsePullResult(resultJson)
+    return SyncManager.refreshFromChangeSet(changeSet).then(() => {
+      if (error) {
+        throw new Error(error)
+      }
+    })
+  }
+
+  private static refreshFromChangeSet(changeSet: NativePullChangeSet | null): Promise<void> {
+    const database = SyncManager.database
+    if (!database || !database.schema || typeof database.notify !== 'function') {
+      return Promise.resolve()
+    }
+    if (changeSet && typeof database.applyNativePullChanges === 'function') {
+      // applyNativePullChanges bounds its work by the JS cache size (not the pull size), so it is
+      // safe to run for pulls of any size — no id-count cap needed.
+      return database.applyNativePullChanges(changeSet).catch((refreshError: unknown) => {
+        // A refresh failure only means stale UI, never data loss (the rows are in SQLite). Surface it
+        // (visible during the Nitro rollout) rather than swallow it.
+        SyncManager.emit({ type: 'error', message: 'native_pull_refresh_failed', error: String(refreshError) })
+      })
+    }
+    // Fallback: no usable changeset (a native build predating the envelope resolves undefined) →
+    // coarse table-level notify so query observers still re-run.
+    const tables = Object.keys(database.schema.tables)
+    if (tables.length > 0) {
+      database.notify(tables)
+    }
+    return Promise.resolve()
+  }
+
+  private static parsePullResult(resultJson: string | void): {
+    changeSet: NativePullChangeSet | null
+    error: string | null
+  } {
+    if (typeof resultJson !== 'string' || resultJson.length === 0) {
+      return { changeSet: null, error: null }
+    }
+    let parsed: any
+    try {
+      parsed = JSON.parse(resultJson)
+    } catch {
+      return { changeSet: null, error: null }
+    }
+    if (!parsed || typeof parsed !== 'object') {
+      return { changeSet: null, error: null }
+    }
+    // Envelope form { changeset, error } (native + JS ship together, so this is what native sends).
+    if ('changeset' in parsed || 'error' in parsed) {
+      const cs = parsed.changeset && typeof parsed.changeset === 'object' ? (parsed.changeset as NativePullChangeSet) : null
+      const err = typeof parsed.error === 'string' && parsed.error.length > 0 ? parsed.error : null
+      return { changeSet: cs, error: err }
+    }
+    // Backward-compat: a bare changeset object from a pre-envelope native.
+    return { changeSet: parsed as NativePullChangeSet, error: null }
   }
 
   static getState(): SyncState {

--- a/src/sync/nativeSync.ts
+++ b/src/sync/nativeSync.ts
@@ -6,7 +6,7 @@ import type { TurboModule } from 'react-native'
 interface NativeSyncModule extends TurboModule {
   configureSync(configJson: string): void
   startSync(reason: string): void
-  syncDatabaseAsync(reason: string): Promise<void>
+  syncDatabaseAsync(reason: string): Promise<string>
   setSyncPullUrl(pullEndpointUrl: string): void
   getSyncStateJson(): string
   addSyncListener(listener: (eventJson: string) => void): number
@@ -52,7 +52,10 @@ export function startSync(reason: string): void {
   module.startSync(reason ?? 'unknown')
 }
 
-export function syncDatabaseAsync(reason: string): Promise<void> {
+// Resolves a JSON envelope on every outcome (even a push failure), so the pulled rows refresh JS
+// regardless: { "changeset": { "<table>": { "upserted": [...], "deleted": [...] } }, "error": string | null }.
+// SyncManager applies the changeset then rethrows any error — see SyncManager.applyNativePullResult.
+export function syncDatabaseAsync(reason: string): Promise<string> {
   const module = getNativeModule()
   return module.syncDatabaseAsync(reason ?? 'unknown')
 }


### PR DESCRIPTION
## MOBILE-6276 — Nitro native pull left JS state stale (+ `_status=NULL` undercounts)

The Nitro native sync engine applies pulled rows straight to SQLite, **bypassing** the WatermelonDB JS write pipeline (`Database.batch` → `notify`). Two confirmed on-device symptoms (QA `qamtt`, PO 9311):
- **Stale UI** — a record cached in JS keeps rendering pre-sync values until app restart.
- **Silent undercounts** — natively-applied rows landed with `_status = NULL`, so the app's pervasive `_status != 'deleted'` raw-SQL filters silently excluded them (e.g. the visit "Purchase orders — N Added" count).

## Approach (target architecture, per design review)

Instead of guessing on the JS side, **native reports exactly what a pull changed** and JS reconciles it through the same path the legacy JS sync uses.

**Native (C++, `native/shared` + both bridges):**
- `SyncApplyEngine.applySyncPayload` records the ids it committed — upserts (full-overwrite + partial-merge) and hard-deletes; **excludes** skipped locally-dirty rows — into a `SyncChangeset`, and sets `_status='synced'`/`_changed=''` on applied rows (was NULL).
- `SyncEngine` accumulates the changeset across paginated pages (guarded by `syncId`, reset at fresh start) and exposes `takeAccumulatedChangesetJson()`.
- iOS + Android bridges resolve `syncDatabaseAsync` with a `{ "changeset": {...}, "error": null|string }` envelope on **every** outcome (success, pull-fail, **push-fail**) — so pulled rows (already in SQLite, cursor advanced) refresh JS even when the push leg fails.

**JS (`src/`):**
- `SyncManager.applyNativePullResult` parses the envelope, applies the changeset via `Database.applyNativePullChanges`, then rethrows any error (caller's pass/fail contract preserved).
- `Database.applyNativePullChanges` refreshes already-cached instances in place (upserts → `_modelForRaw`; deletes → evict + `_notifyDestroyed`) — **bounded by JS cache size, memory-safe, cap-free** — and wakes every changed table's query observers with the **empty (full-refetch) signal** so simple + reloading observers re-query SQLite. Never a partial changeset (avoids the incremental-miss). Load-bearing wake is failure-isolated from the best-effort in-place refresh; warns if native CDC is off.
- Retires the interim `refreshCachedRecords`/notify-all.

Closes the whole stale-cache class at once: directly-observed updates **and** deletes, new rows on un-queried tables, partial-merges, and push-fail.

## Rebased onto MOBILE-6149

Branched before #56 (7.0.4-23) merged. **Rebased onto `main`** so a single version carries both fixes (they touch disjoint files). Published **`@BuildHero/watermelondb@7.0.4-31`** (= 6149 + 6276).

## Testing
- **C++ harness** (`yarn test:cpp` targets): `SyncApplyEngineTests` (changeset reports upsert+delete, excludes dirty, partial-merge reported, empty→`{}`, `_status='synced'` + undercount MRE) and `SyncEngineTests` (cross-page accumulation via `takeAccumulatedChangesetJson`). Green.
- **JS** (`yarn test` + `yarn typecheck`): `Database/notify.test.js` (in-place upsert refresh, delete destroy, uncached-not-materialized, mixed cached+uncached full-refetch, refresh-throw still wakes observers) + `SyncManager.test.js` (envelope apply, push-fail applies-then-rejects, no-changeset fallback, large changeset no-cap). Full suite **290 passing**, tsc clean.
- **iOS native compile:** the `WatermelonDB` pod builds on the iOS simulator (`** BUILD SUCCEEDED **`), compiling `JSISwiftWrapperModule.mm` + `SyncEngine.cpp` + `SyncApplyEngine.cpp`.
- **Android native compile:** app QA-debug build compiles `JSIAndroidBridgeModule.cpp` + the shared engine (arm64) — verifying the Android bridge.
- **On-device authenticated repro** (both platforms, CDC-on production path): to be run via `/auto-qe` / manual QA on `qamtt` with `mobile-nitro-sync` + `enable-purchase-order-rest-api` ON.

## Known limitation (documented follow-up)
The in-place `_raw` refresh depends on native CDC returning full records — which the app's Nitro path always enables (`enableNativeCDC()` before any sync). Without CDC the re-read yields ids and can't refresh in place (logged, not silent); the query-observer wake still reconciles from SQLite. There is no raw-read primitive in the fork to remove this dependency. Also: the published tarball currently includes a stale `native/android/.cxx` build artifact (`.npmignore` gap) — harmless (regenerated by gradle), follow-up to exclude.

App adoption PR: BuildHero/buildhero-mobile (7.0.4-31 bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDrc2YHen7ECtiPj2pDTUf