### PR TITLE
fix(android): serialize writer transactions to fix orphaned-lock crashes - MOBILE-6492

### DIFF
--- a/native/android/src/androidTest/java/com/nozbe/watermelondb/DatabaseTest.kt
+++ b/native/android/src/androidTest/java/com/nozbe/watermelondb/DatabaseTest.kt
@@ -325,4 +325,216 @@ class DatabaseTest {
             readerError.get()
         )
     }
+
+    /**
+     * MOBILE-6492 fix verification. Previously (see git history:
+     * `alreadyOpenConnectionThrowsOnBusyWithNoRetry`), this reproduced a gap left by
+     * MOBILE-5065 / openWithRetry: retry-with-backoff only wrapped the ONE-TIME lazy
+     * `writerDb`/`readerDb` initializer block (open + PRAGMA setup). Once a connection
+     * had already completed that lazy init, every subsequent `execute()` /
+     * `transaction()` call went straight to the raw `SQLiteDatabase` object with zero
+     * retry and no `busy_timeout` — so a SECOND writer that had been open and idle for a
+     * while got no protection at all if it collided with another writer's long
+     * transaction, unlike a freshly-opening connection which openWithRetry covered.
+     *
+     * This was the production shape behind SIP-16015 / MOBILE-6492 (Android
+     * `SQLiteDatabaseLockedException` observed from `sync-coordinator`, `syncDatabase`,
+     * `VisitActions.js`, and `jobRepository.ts` — all long-lived, already-initialized
+     * connections, not fresh connection opens).
+     *
+     * Fix: `writerDb`/`readerDb` now set `PRAGMA busy_timeout=5000` (matching iOS's
+     * `Database.swift#setWalMode`), so SQLite's own native busy-handler waits instead of
+     * failing immediately on an already-open connection's ordinary write.
+     */
+    @Test(timeout = 30000)
+    fun alreadyOpenConnectionWaitsOnBusyInsteadOfThrowing() {
+        val sharedName = "wmdb-post-init-contention-${System.nanoTime()}"
+
+        val db1 = makeDatabaseWithName(sharedName)
+        val db2 = makeDatabaseWithName(sharedName)
+
+        // Force BOTH connections to complete their lazy writerDb init BEFORE the race,
+        // simulating long-lived connections that have already been open for a while —
+        // NOT the connection-init moment openWithRetry protects.
+        db1.execute("CREATE TABLE IF NOT EXISTS test_post_init (id TEXT PRIMARY KEY, value TEXT)")
+        db2.execute("CREATE TABLE IF NOT EXISTS test_post_init (id TEXT PRIMARY KEY, value TEXT)")
+
+        val writerStarted = CountDownLatch(1)
+        val writerDone = CountDownLatch(1)
+        val db2Error = AtomicReference<Throwable?>(null)
+        val db2Done = CountDownLatch(1)
+
+        // Thread 1: hold a write transaction well past requery's ~2.5s built-in busy
+        // timeout — same hold duration as concurrentWritersWithBusyTimeoutDoNotThrow,
+        // which openWithRetry successfully protects against for a FRESH connection.
+        val writerThread = Thread {
+            try {
+                db1.transaction {
+                    db1.execute(
+                        "INSERT OR REPLACE INTO test_post_init (id, value) VALUES (?, ?)",
+                        arrayOf("bg-sync-1", "background-data")
+                    )
+                    writerStarted.countDown()
+                    Thread.sleep(4000)
+                }
+            } finally {
+                writerDone.countDown()
+            }
+        }
+
+        // Thread 2: db2 is ALREADY initialized (see above) — this is an ordinary
+        // post-init write, not a connection open, so it is NOT wrapped in openWithRetry.
+        val secondWriterThread = Thread {
+            try {
+                writerStarted.await(10, TimeUnit.SECONDS)
+                Thread.sleep(50)
+                db2.transaction {
+                    db2.execute(
+                        "INSERT OR REPLACE INTO test_post_init (id, value) VALUES (?, ?)",
+                        arrayOf("fg-action-1", "foreground-data")
+                    )
+                }
+            } catch (e: Throwable) {
+                db2Error.set(e)
+            } finally {
+                db2Done.countDown()
+            }
+        }
+
+        writerThread.start()
+        secondWriterThread.start()
+
+        assertTrue("Writer thread timed out", writerDone.await(20, TimeUnit.SECONDS))
+        assertTrue("Second writer thread timed out", db2Done.await(20, TimeUnit.SECONDS))
+
+        // FIXED: with busy_timeout=5000 set on both writerDb and readerDb, db2's
+        // already-open connection now waits on SQLite's native busy-handler instead of
+        // throwing immediately — same protection concurrentWritersWithBusyTimeoutDoNotThrow
+        // already verified for a freshly-opening connection via openWithRetry.
+        assertNull(
+            "Expected no error now that busy_timeout protects already-open connections, but got: ${db2Error.get()?.message}",
+            db2Error.get()
+        )
+    }
+
+    /**
+     * MOBILE-6492 Tier 2 MRE. Confirmed via production log analysis (Jonathan
+     * DiCamillo, SIP-16015): the real incident was a ~9-minute continuous lock that
+     * survived a full JS re-init — not transient contention. A fixed `busy_timeout`
+     * cannot cover a holder that never releases within that window; it only delays
+     * the eventual throw. This characterizes that gap: a second, independent writer
+     * connection holds a transaction well past `busy_timeout` (Tier 1 fix), and an
+     * ordinary write from a separate already-open connection still throws once the
+     * timeout is exhausted.
+     *
+     * Root cause (confirmed by reading the fork's native sync-apply path):
+     * `JSIAndroidBridgeModule.cpp`'s `ApplyCallback` writes to SQLite via
+     * `Database.kt#acquireSqliteConnection()` + the shared `applySyncPayload()`
+     * free function (`native/shared/SyncApplyEngine.cpp`), entirely OUTSIDE
+     * `Database.kt#transaction()` and with zero serialization against it — unlike
+     * iOS, whose `Database.swift#writerTransactionSemaphore` wraps both
+     * `inTransaction()` and `JSISwiftWrapperModule.mm`'s equivalent sync-apply
+     * callback. Android's `JSIAndroidBridgeModule` has no semaphore/lock equivalent
+     * at all (confirmed via grep — zero synchronization primitives protect the
+     * writer there).
+     *
+     * This test models the two genuinely-separate-connection shape `applySyncPayload`
+     * produces (see `concurrentWritersWithBusyTimeoutDoNotThrow`'s docstring for why
+     * two distinct `Database` instances on the same file reproduce a real SQLite
+     * BUSY, unlike two threads sharing one connection pool, which just serializes at
+     * the Java level).
+     *
+     * Fix (Tier 2, implemented): a per-database-file writer semaphore
+     * (`Database.kt#writerTransactionSemaphore`, shared across every `Database`
+     * instance on the same path via a companion-object map — the Kotlin-level
+     * counterpart of what `DatabaseBridge.kt`'s native accessors will expose to the
+     * `ApplyCallback`), acquired/released around `transaction()` — mirroring iOS's
+     * `writerTransactionSemaphore` exactly. `db2`'s write now waits for `db1` to
+     * release instead of throwing, and only completes after `db1`'s hold duration has
+     * elapsed — verified below by asserting `db2Error` is null and its elapsed time is
+     * at least `holdDurationMs`.
+     */
+    @Test(timeout = 30000)
+    fun orphanedHolderBlocksSecondWriterUntilReleaseInsteadOfThrowing() {
+        val sharedName = "wmdb-orphaned-holder-${System.nanoTime()}"
+        val holdDurationMs = 7000L // comfortably past the 5000ms busy_timeout
+
+        val db1 = makeDatabaseWithName(sharedName)
+        val db2 = makeDatabaseWithName(sharedName)
+
+        // Force both connections to complete their lazy writerDb init before the race
+        // (already-open connections, not the connection-init case openWithRetry covers).
+        db1.execute("CREATE TABLE IF NOT EXISTS test_orphaned_holder (id TEXT PRIMARY KEY, value TEXT)")
+        db2.execute("CREATE TABLE IF NOT EXISTS test_orphaned_holder (id TEXT PRIMARY KEY, value TEXT)")
+
+        val writerStarted = CountDownLatch(1)
+        val writerDone = CountDownLatch(1)
+        val db2Error = AtomicReference<Throwable?>(null)
+        val db2Done = CountDownLatch(1)
+        val db2StartTime = AtomicReference<Long?>(null)
+        val db2EndTime = AtomicReference<Long?>(null)
+
+        // Thread 1: simulates the native sync-apply path's transaction, held well past
+        // busy_timeout — standing in for a background-sync writer that never releases
+        // within a reasonable window (WorkManager kill / unsafe ON_START cancel).
+        val writerThread = Thread {
+            try {
+                db1.transaction {
+                    db1.execute(
+                        "INSERT OR REPLACE INTO test_orphaned_holder (id, value) VALUES (?, ?)",
+                        arrayOf("bg-sync-1", "background-data")
+                    )
+                    writerStarted.countDown()
+                    Thread.sleep(holdDurationMs)
+                }
+            } finally {
+                writerDone.countDown()
+            }
+        }
+
+        // Thread 2: an ordinary already-open-connection write, simulating a foreground
+        // visit-action write colliding with the orphaned background writer.
+        val secondWriterThread = Thread {
+            try {
+                writerStarted.await(10, TimeUnit.SECONDS)
+                Thread.sleep(50)
+                db2StartTime.set(System.currentTimeMillis())
+                db2.transaction {
+                    db2.execute(
+                        "INSERT OR REPLACE INTO test_orphaned_holder (id, value) VALUES (?, ?)",
+                        arrayOf("fg-action-1", "foreground-data")
+                    )
+                }
+                db2EndTime.set(System.currentTimeMillis())
+            } catch (e: Throwable) {
+                db2Error.set(e)
+            } finally {
+                db2Done.countDown()
+            }
+        }
+
+        writerThread.start()
+        secondWriterThread.start()
+
+        assertTrue("Writer thread timed out", writerDone.await(20, TimeUnit.SECONDS))
+        assertTrue("Second writer thread timed out", db2Done.await(20, TimeUnit.SECONDS))
+
+        // FIXED (Tier 2): the writer semaphore makes db2 wait for db1 to release
+        // rather than racing SQLite's busy_timeout — no exception, regardless of how
+        // long db1 holds the lock.
+        assertNull(
+            "Expected no error now that the writer semaphore serializes db2 against " +
+                "db1's transaction, but got: ${db2Error.get()?.message}",
+            db2Error.get()
+        )
+
+        // And it must have genuinely WAITED for the semaphore (not raced SQLite and
+        // gotten lucky) — db2's write should only complete at or after db1's release.
+        val elapsedMs = (db2EndTime.get() ?: 0L) - (db2StartTime.get() ?: 0L)
+        assertTrue(
+            "Expected db2 to wait at least ${holdDurationMs}ms for db1's semaphore release, " +
+                "but only waited ${elapsedMs}ms",
+            elapsedMs >= holdDurationMs - 200 // small tolerance for scheduling jitter
+        )
+    }
 }

--- a/native/android/src/androidTest/java/com/nozbe/watermelondb/DatabaseTest.kt
+++ b/native/android/src/androidTest/java/com/nozbe/watermelondb/DatabaseTest.kt
@@ -537,4 +537,360 @@ class DatabaseTest {
             elapsedMs >= holdDurationMs - 200 // small tolerance for scheduling jitter
         )
     }
+
+    /**
+     * MOBILE-6492 — the case the incident actually was, and the one
+     * `orphanedHolderBlocksSecondWriterUntilReleaseInsteadOfThrowing` above does NOT
+     * cover: a holder that never releases at all.
+     *
+     * That test sleeps 7s and then releases, so it only proves a *bounded* hold no
+     * longer throws. The reported failure was a native sync-apply transaction orphaned
+     * by the ON_START foreground-cancel path (which resets bookkeeping without rolling
+     * back) — the lock was held for 9 minutes and survived a full JS re-init. Against a
+     * holder like that, an unbounded `Semaphore.acquire()` never returns, converting a
+     * visible SQLiteDatabaseLockedException into a permanent silent stall of every
+     * writer on the file.
+     *
+     * So the invariant under test is liveness, not success: a writer must always come
+     * back — with or without an error — inside a bound derived from
+     * `writerSemaphoreTimeoutMs`. It must never hang.
+     */
+    @Test
+    fun wedgedHolderDoesNotBlockSecondWriterForever() {
+        val sharedName = "wmdb-wedged-holder-${System.nanoTime()}"
+        val timeoutMs = 2000L
+
+        val originalTimeout = Database.writerSemaphoreTimeoutMs
+        Database.writerSemaphoreTimeoutMs = timeoutMs
+        try {
+            val db1 = makeDatabaseWithName(sharedName)
+            val db2 = makeDatabaseWithName(sharedName)
+            db1.execute(
+                "CREATE TABLE IF NOT EXISTS test_wedged (id TEXT PRIMARY KEY, value TEXT)"
+            )
+
+            // Take the permit through the same accessor the native sync-apply path uses
+            // and deliberately NEVER release it — standing in for the orphaned native
+            // apply transaction. No matching release anywhere in this test.
+            assertTrue(
+                "Precondition: the wedging acquire should succeed on an idle semaphore",
+                db1.acquireWriterTransactionSemaphore()
+            )
+
+            val db2Done = CountDownLatch(1)
+            val db2Error = AtomicReference<Throwable?>(null)
+            val startMs = System.currentTimeMillis()
+
+            Thread {
+                try {
+                    db2.transaction {
+                        db2.execute(
+                            "INSERT OR REPLACE INTO test_wedged (id, value) VALUES (?, ?)",
+                            arrayOf("w1", "written-despite-wedge")
+                        )
+                    }
+                } catch (t: Throwable) {
+                    db2Error.set(t)
+                } finally {
+                    db2Done.countDown()
+                }
+            }.start()
+
+            // The assertion that matters: it RETURNS. Generous ceiling so this fails on
+            // a genuine hang, not on emulator jitter. Pre-fix this times out here.
+            assertTrue(
+                "Second writer never returned — it is blocked forever behind a holder " +
+                    "that never releases (unbounded acquire regression)",
+                db2Done.await(timeoutMs * 5, TimeUnit.MILLISECONDS)
+            )
+
+            // It must have actually waited for the bound rather than sailing past a
+            // semaphore that was not really held.
+            val elapsedMs = System.currentTimeMillis() - startMs
+            assertTrue(
+                "Expected the writer to wait out the ${timeoutMs}ms bound, waited ${elapsedMs}ms",
+                elapsedMs >= timeoutMs - 200
+            )
+
+            // Whether the write itself succeeded is deliberately NOT asserted: past the
+            // bound we proceed unserialized and busy_timeout arbitrates, so either
+            // outcome is correct. Only hanging is a failure.
+        } finally {
+            Database.writerSemaphoreTimeoutMs = originalTimeout
+        }
+    }
+
+    /**
+     * MOBILE-6492 — the writer semaphore must be reentrant.
+     *
+     * `Database.transaction()` nests in production. Both `DatabaseDriver.setUpSchema`
+     * and `.migrate` do:
+     *
+     *     database.transaction {                        // takes the only permit
+     *         database.unsafeExecuteStatements(sql)     // transacts AGAIN, same thread
+     *         database.userVersion = ...
+     *     }
+     *
+     * and `unsafeExecuteStatements` is itself `transaction { ... }`. `Semaphore(1)` is
+     * not reentrant, so a non-reentrant implementation makes the inner frame wait on the
+     * permit its own thread holds — a self-deadlock with no counterparty to release it.
+     * Those two call sites are first-launch schema setup and every app upgrade carrying
+     * a migration, so this must never regress.
+     *
+     * The existing suite cannot catch it: every other test drives `Database` directly
+     * and never goes through `DatabaseDriver`, so neither nesting path is exercised.
+     * This test reproduces the nesting shape against the same public API.
+     */
+    @Test
+    fun nestedTransactionDoesNotSelfDeadlock() {
+        val timeoutMs = 1500L
+        val originalTimeout = Database.writerSemaphoreTimeoutMs
+        // Deliberately short: if reentrancy regresses, the inner frame blocks and this
+        // fails fast on the latch below instead of stalling the whole suite.
+        Database.writerSemaphoreTimeoutMs = timeoutMs
+        try {
+            val database = makeDatabase()
+            database.execute(
+                "CREATE TABLE IF NOT EXISTS test_nested (id TEXT PRIMARY KEY, value TEXT)"
+            )
+
+            val done = CountDownLatch(1)
+            val failure = AtomicReference<Throwable?>(null)
+            val startMs = System.currentTimeMillis()
+
+            Thread {
+                try {
+                    // Mirrors DatabaseDriver.setUpSchema: an outer transaction wrapping
+                    // unsafeExecuteStatements, which opens its own inner transaction.
+                    database.transaction {
+                        database.unsafeExecuteStatements(
+                            "INSERT OR REPLACE INTO test_nested (id, value) VALUES ('n1', 'inner');"
+                        )
+                        database.userVersion = 42
+                    }
+                } catch (t: Throwable) {
+                    failure.set(t)
+                } finally {
+                    done.countDown()
+                }
+            }.start()
+
+            assertTrue(
+                "Nested transaction never completed — the inner frame is deadlocked on " +
+                    "the permit its own thread holds (writer semaphore lost reentrancy)",
+                done.await(timeoutMs * 4, TimeUnit.MILLISECONDS)
+            )
+            assertNull("Nested transaction threw: ${failure.get()?.message}", failure.get())
+
+            // It must not have merely *survived* by timing out the inner acquire — that
+            // would still stall every schema setup and migration for the bound.
+            val elapsedMs = System.currentTimeMillis() - startMs
+            assertTrue(
+                "Nested transaction took ${elapsedMs}ms — it waited out the semaphore " +
+                    "bound instead of re-entering, so reentrancy is not working",
+                elapsedMs < timeoutMs
+            )
+
+            // The nested write really landed, and the permit was fully surrendered.
+            assertEquals(42, database.userVersion)
+            assertEquals(
+                "Permit must be back to exactly 1 after the outermost frame exits",
+                1,
+                database.availableWriterPermitsForTest()
+            )
+        } finally {
+            Database.writerSemaphoreTimeoutMs = originalTimeout
+        }
+    }
+
+    /**
+     * MOBILE-6492 — the writer-contention counters must capture the two facts a field
+     * investigation cannot otherwise get.
+     *
+     * The on-device issue report is assembled from the JS logger and captures no
+     * logcat, so `Database`'s `Log.w` on a timeout never reaches it. A sweep of 1,198
+     * production reports could therefore establish which call sites were *failing*
+     * (sync-coordinator, syncDatabase, JobTaskSync) but never which writer was
+     * *holding*, nor for how long — which is exactly what distinguishes a wedged
+     * holder from ordinary transient contention.
+     *
+     * So this pins both: the holder named at timeout, and `maxWaitMs` as a real
+     * measurement of how long another writer held the file.
+     */
+    @Test
+    fun writerContentionStatsRecordHolderAndWaitDuration() {
+        val sharedName = "wmdb-contention-stats-${System.nanoTime()}"
+        val timeoutMs = 800L
+        val holdMs = 400L
+
+        val originalTimeout = Database.writerSemaphoreTimeoutMs
+        Database.writerSemaphoreTimeoutMs = timeoutMs
+        try {
+            val db1 = makeDatabaseWithName(sharedName)
+            val db2 = makeDatabaseWithName(sharedName)
+
+            // 1. A timeout must name the holder that caused it.
+            assertTrue(
+                "Precondition: first acquire on an idle semaphore",
+                db1.acquireWriterTransactionSemaphore("test-holder")
+            )
+
+            val timedOutResult = AtomicReference<Boolean?>(null)
+            val timeoutDone = CountDownLatch(1)
+            Thread {
+                try {
+                    timedOutResult.set(db2.acquireWriterTransactionSemaphore())
+                } finally {
+                    timeoutDone.countDown()
+                }
+            }.start()
+
+            assertTrue(
+                "Contender never returned from acquire",
+                timeoutDone.await(timeoutMs * 6, TimeUnit.MILLISECONDS)
+            )
+            assertFalse("Contender should have timed out", timedOutResult.get()!!)
+
+            val afterTimeout = db1.writerContentionSnapshot()
+            assertEquals("One timeout should be recorded", 1L, afterTimeout["timeouts"])
+            assertEquals(
+                "The timeout must name the writer that was holding the permit",
+                "test-holder",
+                afterTimeout["lastTimeoutHolder"]
+            )
+
+            db1.releaseWriterTransactionSemaphore()
+
+            // 2. A contended-but-successful acquire must record how long it waited —
+            //    the proxy for how long the other writer actually held the file.
+            assertTrue(
+                "Re-acquire after release",
+                db1.acquireWriterTransactionSemaphore("holder-2")
+            )
+
+            val waitedResult = AtomicReference<Boolean?>(null)
+            val waitDone = CountDownLatch(1)
+            Thread {
+                try {
+                    val got = db2.acquireWriterTransactionSemaphore()
+                    waitedResult.set(got)
+                    // Release on the acquiring thread: reentrancy depth is per-thread,
+                    // so a cross-thread release would find depth 0 and correctly refuse.
+                    if (got) db2.releaseWriterTransactionSemaphore()
+                } finally {
+                    waitDone.countDown()
+                }
+            }.start()
+
+            Thread.sleep(holdMs)
+            db1.releaseWriterTransactionSemaphore()
+
+            assertTrue(
+                "Waiting writer never completed",
+                waitDone.await(timeoutMs * 6, TimeUnit.MILLISECONDS)
+            )
+            assertTrue(
+                "The waiting writer should have succeeded once the hold ended",
+                waitedResult.get()!!
+            )
+
+            val afterWait = db2.writerContentionSnapshot()
+            val maxWaitMs = afterWait["maxWaitMs"] as Long
+            assertTrue(
+                "maxWaitMs should reflect the ~${holdMs}ms hold, got ${maxWaitMs}ms",
+                maxWaitMs >= holdMs - 150
+            )
+            assertTrue(
+                "The contended acquire should have been counted, got ${afterWait["contendedAcquires"]}",
+                (afterWait["contendedAcquires"] as Long) >= 1L
+            )
+            assertEquals(
+                "The reported bound should be the active timeout",
+                timeoutMs,
+                afterWait["timeoutBoundMs"]
+            )
+        } finally {
+            Database.writerSemaphoreTimeoutMs = originalTimeout
+        }
+    }
+
+    /**
+     * MOBILE-6492 — guards the silent-no-op bug: releasing a binary Semaphore without a
+     * matching acquire *raises* its permit count (1 -> 2), after which two writers hold
+     * it simultaneously and Tier 2's mutual exclusion is gone for the life of the
+     * process, with every existing test still green.
+     *
+     * The reachable path was the JNI boundary: `acquireWriterSemaphore` used to return
+     * void, so a failure (no env/class, missing method, or a Java-side throw cleared by
+     * ExceptionCheck) was indistinguishable from success and the caller released
+     * anyway. Acquire now reports success and callers release only on true; this pins
+     * the invariant that a failed acquire followed by no release cannot inflate permits.
+     */
+    @Test
+    fun failedAcquireDoesNotInflatePermits() {
+        val sharedName = "wmdb-permit-inflation-${System.nanoTime()}"
+        val timeoutMs = 500L
+
+        val originalTimeout = Database.writerSemaphoreTimeoutMs
+        Database.writerSemaphoreTimeoutMs = timeoutMs
+        try {
+            val db1 = makeDatabaseWithName(sharedName)
+            val db2 = makeDatabaseWithName(sharedName)
+
+            assertTrue("First acquire should succeed", db1.acquireWriterTransactionSemaphore())
+            assertEquals(
+                "Binary semaphore should have no permits left while held",
+                0,
+                db1.availableWriterPermitsForTest()
+            )
+
+            // The contending acquire MUST run on another thread. Reentrancy is keyed on
+            // (thread, database file), so a second acquire on *this* thread would
+            // correctly re-enter and return true — that is the nesting case, not the
+            // contention case. Only a different thread actually contends for the permit.
+            val contenderResult = AtomicReference<Boolean?>(null)
+            val contenderDone = CountDownLatch(1)
+            Thread {
+                try {
+                    contenderResult.set(db2.acquireWriterTransactionSemaphore())
+                } finally {
+                    contenderDone.countDown()
+                }
+            }.start()
+
+            assertTrue(
+                "Contending thread never returned from acquire",
+                contenderDone.await(timeoutMs * 6, TimeUnit.MILLISECONDS)
+            )
+            assertFalse(
+                "A contending thread's acquire must time out and report false while " +
+                    "another thread holds the permit",
+                contenderResult.get()!!
+            )
+
+            // The failed acquirer correctly does not release. Only the real holder does.
+            db1.releaseWriterTransactionSemaphore()
+
+            assertEquals(
+                "Permit count must return to exactly 1 — anything higher means an " +
+                    "unmatched release inflated the semaphore and mutual exclusion is void",
+                1,
+                db1.availableWriterPermitsForTest()
+            )
+
+            // And exclusion still holds afterwards: one permit, taken by one acquirer.
+            assertTrue(
+                "Acquire should work after a clean release",
+                db1.acquireWriterTransactionSemaphore()
+            )
+            assertEquals(
+                "Still a binary semaphore after a full acquire/release cycle",
+                0,
+                db1.availableWriterPermitsForTest()
+            )
+            db1.releaseWriterTransactionSemaphore()
+        } finally {
+            Database.writerSemaphoreTimeoutMs = originalTimeout
+        }
+    }
 }

--- a/native/android/src/main/cpp/JSIAndroidBridgeModule.cpp
+++ b/native/android/src/main/cpp/JSIAndroidBridgeModule.cpp
@@ -232,6 +232,58 @@ static void releaseSqlite(jobject bridge, jint tag) {
     }
 }
 
+// MOBILE-6492 (Tier 2): serialize this native sync-apply path against JS-driven
+// Database.kt#transaction() writes on the same file. Mirrors iOS's
+// JSISwiftWrapperModule.mm, which wraps its equivalent apply callback in
+// writerTransactionSemaphore.wait()/signal() around getRawConnection/applySyncPayload.
+// Blocking call (Semaphore.acquire() on the Kotlin side) — this callback already runs
+// off the JS thread (OkHttp's callback thread), so blocking here is safe.
+static void acquireWriterSemaphore(jobject bridge, jint tag, const char* holderName) {
+    JNIEnv* env = facebook::jni::Environment::current();
+    if (!env || !bridge) {
+        return;
+    }
+    jclass cls = env->GetObjectClass(bridge);
+    if (!cls) {
+        env->ExceptionClear();
+        return;
+    }
+    jmethodID acquireSem = env->GetMethodID(cls, "acquireWriterTransactionSemaphore", "(ILjava/lang/String;)V");
+    if (acquireSem) {
+        jstring jHolderName = env->NewStringUTF(holderName);
+        env->CallVoidMethod(bridge, acquireSem, tag, jHolderName);
+        env->DeleteLocalRef(jHolderName);
+    } else {
+        env->ExceptionClear();
+    }
+    env->DeleteLocalRef(cls);
+    if (env->ExceptionCheck()) {
+        env->ExceptionClear();
+    }
+}
+
+static void releaseWriterSemaphore(jobject bridge, jint tag) {
+    JNIEnv* env = facebook::jni::Environment::current();
+    if (!env || !bridge) {
+        return;
+    }
+    jclass cls = env->GetObjectClass(bridge);
+    if (!cls) {
+        env->ExceptionClear();
+        return;
+    }
+    jmethodID releaseSem = env->GetMethodID(cls, "releaseWriterTransactionSemaphore", "(I)V");
+    if (releaseSem) {
+        env->CallVoidMethod(bridge, releaseSem, tag);
+    } else {
+        env->ExceptionClear();
+    }
+    env->DeleteLocalRef(cls);
+    if (env->ExceptionCheck()) {
+        env->ExceptionClear();
+    }
+}
+
 JSIAndroidBridgeModule::JSIAndroidBridgeModule(std::shared_ptr<CallInvoker> jsInvoker)
 : NativeWatermelonDBModuleCxxSpec(std::move(jsInvoker)) {
     {
@@ -254,14 +306,21 @@ JSIAndroidBridgeModule::JSIAndroidBridgeModule(std::shared_ptr<CallInvoker> jsIn
             errorMessage = "DatabaseBridge not available";
             return false;
         }
+        // MOBILE-6492 (Tier 2): acquire before touching SQLite, release after —
+        // matches iOS's JSISwiftWrapperModule.mm wait()/signal() around this same
+        // apply-and-write sequence. Without this, this write raced JS-driven
+        // Database.kt#transaction() calls on the same file with no serialization.
+        acquireWriterSemaphore(databaseBridge, (jint)syncConnectionTag_, "native-sync:apply");
         std::string error;
         sqlite3* db = acquireSqlite(databaseBridge, (jint)syncConnectionTag_, error);
         if (!db) {
             errorMessage = error;
+            releaseWriterSemaphore(databaseBridge, (jint)syncConnectionTag_);
             return false;
         }
         bool ok = watermelondb::applySyncPayload(db, payload, errorMessage, changeset);
         releaseSqlite(databaseBridge, (jint)syncConnectionTag_);
+        releaseWriterSemaphore(databaseBridge, (jint)syncConnectionTag_);
         return ok;
     });
     syncEngine_->setAuthTokenRequestCallback([this]() {

--- a/native/android/src/main/cpp/JSIAndroidBridgeModule.cpp
+++ b/native/android/src/main/cpp/JSIAndroidBridgeModule.cpp
@@ -238,20 +238,28 @@ static void releaseSqlite(jobject bridge, jint tag) {
 // writerTransactionSemaphore.wait()/signal() around getRawConnection/applySyncPayload.
 // Blocking call (Semaphore.acquire() on the Kotlin side) — this callback already runs
 // off the JS thread (OkHttp's callback thread), so blocking here is safe.
-static void acquireWriterSemaphore(jobject bridge, jint tag, const char* holderName) {
+// Returns true only if the permit was actually taken — the caller must release iff it
+// gets true. Every early-out below returns false: previously this returned void, so a
+// JNI failure (no env, no class, missing method, or a Java-side throw cleared by the
+// ExceptionCheck at the end) was indistinguishable from success, and the caller went on
+// to release a permit it never held. On a binary semaphore that *raises* the permit
+// count from 1 to 2 and silently voids mutual exclusion for the process's lifetime —
+// turning Tier 2 into a no-op that still passes every test.
+static bool acquireWriterSemaphore(jobject bridge, jint tag, const char* holderName) {
     JNIEnv* env = facebook::jni::Environment::current();
     if (!env || !bridge) {
-        return;
+        return false;
     }
     jclass cls = env->GetObjectClass(bridge);
     if (!cls) {
         env->ExceptionClear();
-        return;
+        return false;
     }
-    jmethodID acquireSem = env->GetMethodID(cls, "acquireWriterTransactionSemaphore", "(ILjava/lang/String;)V");
+    jmethodID acquireSem = env->GetMethodID(cls, "acquireWriterTransactionSemaphore", "(ILjava/lang/String;)Z");
+    bool acquired = false;
     if (acquireSem) {
         jstring jHolderName = env->NewStringUTF(holderName);
-        env->CallVoidMethod(bridge, acquireSem, tag, jHolderName);
+        acquired = env->CallBooleanMethod(bridge, acquireSem, tag, jHolderName) == JNI_TRUE;
         env->DeleteLocalRef(jHolderName);
     } else {
         env->ExceptionClear();
@@ -259,7 +267,11 @@ static void acquireWriterSemaphore(jobject bridge, jint tag, const char* holderN
     env->DeleteLocalRef(cls);
     if (env->ExceptionCheck()) {
         env->ExceptionClear();
+        // A pending throw means the Kotlin side did not complete; its return value is
+        // not trustworthy, so treat this as "not acquired" and never release.
+        acquired = false;
     }
+    return acquired;
 }
 
 static void releaseWriterSemaphore(jobject bridge, jint tag) {
@@ -283,6 +295,33 @@ static void releaseWriterSemaphore(jobject bridge, jint tag) {
         env->ExceptionClear();
     }
 }
+
+// MOBILE-6492: RAII pairing for the writer semaphore. Releases exactly once, and only
+// if the acquire succeeded, on every exit path — early return, or a throw out of
+// applySyncPayload (its STL container work can raise std::bad_alloc under the memory
+// pressure that a wedged, WAL-growing database makes more likely, and a leaked permit
+// there would deadlock every writer until process death).
+class WriterSemaphoreGuard {
+public:
+    WriterSemaphoreGuard(jobject bridge, jint tag, const char* holderName)
+        : bridge_(bridge), tag_(tag), held_(acquireWriterSemaphore(bridge, tag, holderName)) {}
+
+    ~WriterSemaphoreGuard() {
+        if (held_) {
+            releaseWriterSemaphore(bridge_, tag_);
+        }
+    }
+
+    bool held() const { return held_; }
+
+    WriterSemaphoreGuard(const WriterSemaphoreGuard&) = delete;
+    WriterSemaphoreGuard& operator=(const WriterSemaphoreGuard&) = delete;
+
+private:
+    jobject bridge_;
+    jint tag_;
+    bool held_;
+};
 
 JSIAndroidBridgeModule::JSIAndroidBridgeModule(std::shared_ptr<CallInvoker> jsInvoker)
 : NativeWatermelonDBModuleCxxSpec(std::move(jsInvoker)) {
@@ -310,17 +349,21 @@ JSIAndroidBridgeModule::JSIAndroidBridgeModule(std::shared_ptr<CallInvoker> jsIn
         // matches iOS's JSISwiftWrapperModule.mm wait()/signal() around this same
         // apply-and-write sequence. Without this, this write raced JS-driven
         // Database.kt#transaction() calls on the same file with no serialization.
-        acquireWriterSemaphore(databaseBridge, (jint)syncConnectionTag_, "native-sync:apply");
+        //
+        // Proceed even when the permit was not granted (timeout, or a JNI failure):
+        // busy_timeout arbitrates at the SQLite layer, exactly as on the JS path in
+        // Database.kt#transaction(). Bailing out here instead would convert a
+        // contended sync into a failed one and stall the pull cursor.
+        WriterSemaphoreGuard writerGuard(
+            databaseBridge, (jint)syncConnectionTag_, "native-sync:apply");
         std::string error;
         sqlite3* db = acquireSqlite(databaseBridge, (jint)syncConnectionTag_, error);
         if (!db) {
             errorMessage = error;
-            releaseWriterSemaphore(databaseBridge, (jint)syncConnectionTag_);
             return false;
         }
         bool ok = watermelondb::applySyncPayload(db, payload, errorMessage, changeset);
         releaseSqlite(databaseBridge, (jint)syncConnectionTag_);
-        releaseWriterSemaphore(databaseBridge, (jint)syncConnectionTag_);
         return ok;
     });
     syncEngine_->setAuthTokenRequestCallback([this]() {

--- a/native/android/src/main/cpp/SliceImportDatabaseAdapterAndroid.cpp
+++ b/native/android/src/main/cpp/SliceImportDatabaseAdapterAndroid.cpp
@@ -65,6 +65,7 @@ public:
         : bridgeGlobal_(nullptr)
         , connectionTag_(connectionTag)
         , transactionStarted_(false)
+        , semaphoreHeld_(false)
         , db_(nullptr) {
         JNIEnv* env = watermelondb::getEnv();
         if (env && bridge) {
@@ -93,7 +94,14 @@ public:
                 ok = false;
                 return;
             }
+            // MOBILE-6492 (Tier 2): acquire before touching SQLite, matching iOS's
+            // SliceImportDatabaseAdapter.mm::beginTransaction (wait() before BEGIN
+            // IMMEDIATE) — serializes slice-import writes against JS-driven
+            // Database.kt#transaction() and the native sync-apply path on the same file.
+            acquireWriterSemaphore();
+            semaphoreHeld_ = true;
             if (!ensureConnection(errorMessage)) {
+                releaseWriterSemaphoreIfHeld();
                 ok = false;
                 return;
             }
@@ -106,6 +114,7 @@ public:
             execSQL(db_, "PRAGMA wal_autocheckpoint=10000;", ignored);
             if (!execSQL(db_, "BEGIN IMMEDIATE;", errorMessage)) {
                 releaseConnection();
+                releaseWriterSemaphoreIfHeld();
                 ok = false;
                 return;
             }
@@ -113,6 +122,7 @@ public:
             ownerThread_ = std::this_thread::get_id();
             ok = true;
         }, &errorMessage)) {
+            releaseWriterSemaphoreIfHeld();
             return false;
         }
         return ok;
@@ -147,8 +157,13 @@ public:
             releaseConnection();
             ok = true;
         }, &errorMessage)) {
+            releaseWriterSemaphoreIfHeld();
             return false;
         }
+        // Release after commit (or the internal rollback-on-commit-failure path
+        // above) has fully released the connection — mirrors iOS releasing the
+        // semaphore once its equivalent commit sequence completes.
+        releaseWriterSemaphoreIfHeld();
         return ok;
     }
 
@@ -160,6 +175,7 @@ public:
             rollbackTransactionOnDB();
             releaseConnection();
         }, nullptr);
+        releaseWriterSemaphoreIfHeld();
     }
 
     bool insertRows(const std::string &tableName,
@@ -236,9 +252,64 @@ private:
     jobject bridgeGlobal_;
     jint connectionTag_;
     bool transactionStarted_;
+    bool semaphoreHeld_;
     sqlite3* db_;
     std::thread::id ownerThread_;
     watermelondb::SqliteInsertHelper insertHelper_;
+
+    // MOBILE-6492 (Tier 2): same per-connection-tag writer semaphore
+    // JSIAndroidBridgeModule.cpp's ApplyCallback and Database.kt#transaction() use —
+    // completes the three-writer-path parity with iOS (inTransaction /
+    // SliceImportDatabaseAdapter::beginTransaction / native-sync-apply).
+    void acquireWriterSemaphore() {
+        JNIEnv* env = watermelondb::getEnv();
+        if (!env || !bridgeGlobal_) {
+            return;
+        }
+        jclass cls = env->GetObjectClass(bridgeGlobal_);
+        if (!cls) {
+            env->ExceptionClear();
+            return;
+        }
+        jmethodID acquireSem = env->GetMethodID(cls, "acquireWriterTransactionSemaphore", "(ILjava/lang/String;)V");
+        if (acquireSem) {
+            jstring jHolderName = env->NewStringUTF("slice-import");
+            env->CallVoidMethod(bridgeGlobal_, acquireSem, connectionTag_, jHolderName);
+            env->DeleteLocalRef(jHolderName);
+        } else {
+            env->ExceptionClear();
+        }
+        env->DeleteLocalRef(cls);
+        if (env->ExceptionCheck()) {
+            env->ExceptionClear();
+        }
+    }
+
+    void releaseWriterSemaphoreIfHeld() {
+        if (!semaphoreHeld_) {
+            return;
+        }
+        semaphoreHeld_ = false;
+        JNIEnv* env = watermelondb::getEnv();
+        if (!env || !bridgeGlobal_) {
+            return;
+        }
+        jclass cls = env->GetObjectClass(bridgeGlobal_);
+        if (!cls) {
+            env->ExceptionClear();
+            return;
+        }
+        jmethodID releaseSem = env->GetMethodID(cls, "releaseWriterTransactionSemaphore", "(I)V");
+        if (releaseSem) {
+            env->CallVoidMethod(bridgeGlobal_, releaseSem, connectionTag_);
+        } else {
+            env->ExceptionClear();
+        }
+        env->DeleteLocalRef(cls);
+        if (env->ExceptionCheck()) {
+            env->ExceptionClear();
+        }
+    }
 
     bool ensureConnection(std::string &errorMessage) {
         if (db_) {

--- a/native/android/src/main/cpp/SliceImportDatabaseAdapterAndroid.cpp
+++ b/native/android/src/main/cpp/SliceImportDatabaseAdapterAndroid.cpp
@@ -98,8 +98,11 @@ public:
             // SliceImportDatabaseAdapter.mm::beginTransaction (wait() before BEGIN
             // IMMEDIATE) — serializes slice-import writes against JS-driven
             // Database.kt#transaction() and the native sync-apply path on the same file.
-            acquireWriterSemaphore();
-            semaphoreHeld_ = true;
+            // Track only what was actually granted. Setting this unconditionally would
+            // let a timed-out or JNI-failed acquire be "released" later, raising the
+            // binary semaphore's permit count and silently voiding mutual exclusion.
+            // Proceed either way — busy_timeout above arbitrates at the SQLite layer.
+            semaphoreHeld_ = acquireWriterSemaphore();
             if (!ensureConnection(errorMessage)) {
                 releaseWriterSemaphoreIfHeld();
                 ok = false;
@@ -261,20 +264,24 @@ private:
     // JSIAndroidBridgeModule.cpp's ApplyCallback and Database.kt#transaction() use —
     // completes the three-writer-path parity with iOS (inTransaction /
     // SliceImportDatabaseAdapter::beginTransaction / native-sync-apply).
-    void acquireWriterSemaphore() {
+    // Returns true only if the permit was actually taken. The caller must record this
+    // into semaphoreHeld_ and release iff it is true — see the note at the call site.
+    bool acquireWriterSemaphore() {
         JNIEnv* env = watermelondb::getEnv();
         if (!env || !bridgeGlobal_) {
-            return;
+            return false;
         }
         jclass cls = env->GetObjectClass(bridgeGlobal_);
         if (!cls) {
             env->ExceptionClear();
-            return;
+            return false;
         }
-        jmethodID acquireSem = env->GetMethodID(cls, "acquireWriterTransactionSemaphore", "(ILjava/lang/String;)V");
+        jmethodID acquireSem = env->GetMethodID(cls, "acquireWriterTransactionSemaphore", "(ILjava/lang/String;)Z");
+        bool acquired = false;
         if (acquireSem) {
             jstring jHolderName = env->NewStringUTF("slice-import");
-            env->CallVoidMethod(bridgeGlobal_, acquireSem, connectionTag_, jHolderName);
+            acquired = env->CallBooleanMethod(
+                bridgeGlobal_, acquireSem, connectionTag_, jHolderName) == JNI_TRUE;
             env->DeleteLocalRef(jHolderName);
         } else {
             env->ExceptionClear();
@@ -282,7 +289,11 @@ private:
         env->DeleteLocalRef(cls);
         if (env->ExceptionCheck()) {
             env->ExceptionClear();
+            // Pending throw — the Kotlin side did not complete, so its return value is
+            // not trustworthy. Treat as not acquired and never release.
+            acquired = false;
         }
+        return acquired;
     }
 
     void releaseWriterSemaphoreIfHeld() {

--- a/native/android/src/main/java/com/nozbe/watermelondb/Database.kt
+++ b/native/android/src/main/java/com/nozbe/watermelondb/Database.kt
@@ -13,15 +13,64 @@ import android.util.Log
 import java.io.File
 import java.lang.reflect.Field
 import java.lang.reflect.Method
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Semaphore
 
 class Database(private val name: String, private val context: Context) {
 
     private val databasePath: String = resolveDatabasePath()
     private val transactionDepth = ThreadLocal<Int>()
 
+    companion object {
+        // MOBILE-6492 (Tier 2): one binary semaphore per underlying database file,
+        // shared across every `Database` instance (and, via DatabaseBridge's JNI
+        // accessors, the native sync-apply path) pointing at that same path. This is
+        // the Android port of iOS's `Database.swift#writerTransactionSemaphore` —
+        // Android's native sync-apply callback (`JSIAndroidBridgeModule.cpp`) writes
+        // to this same connection via `acquireSqliteConnection()` below, entirely
+        // outside `transaction()`'s own bookkeeping, so the semaphore must live at a
+        // scope both paths can reach, keyed by the one thing they agree on: the file.
+        private val writerTransactionSemaphores = ConcurrentHashMap<String, Semaphore>()
+        private val writerHolders = ConcurrentHashMap<String, String>()
+
+        internal fun writerTransactionSemaphoreFor(path: String): Semaphore =
+            writerTransactionSemaphores.getOrPut(path) { Semaphore(1) }
+    }
+
+    private val writerTransactionSemaphore: Semaphore
+        get() = writerTransactionSemaphoreFor(databasePath)
+
+    internal fun setWriterHolder(name: String) {
+        writerHolders[databasePath] = name
+    }
+
+    internal fun clearWriterHolder() {
+        writerHolders.remove(databasePath)
+    }
+
+    internal fun currentWriterHolder(): String? = writerHolders[databasePath]
+
+    // MOBILE-6492 (Tier 2): exposed for DatabaseBridge's JNI accessors, so the native
+    // sync-apply path (JSIAndroidBridgeModule.cpp's ApplyCallback) can acquire/release
+    // the same semaphore transaction() uses, around its own acquireSqliteConnection()/
+    // applySyncPayload()/releaseSQLiteConnection() sequence — mirroring iOS's
+    // JSISwiftWrapperModule.mm wait()/signal() around getRawConnection/applySyncPayload.
+    // Blocking — callers must invoke off the JS thread.
+    fun acquireWriterTransactionSemaphore() {
+        writerTransactionSemaphore.acquire()
+    }
+
+    fun releaseWriterTransactionSemaphore() {
+        writerTransactionSemaphore.release()
+    }
+
     private val writerDb: SQLiteDatabase by lazy {
         openWithRetry {
             SQLiteDatabase.openOrCreateDatabase(databasePath, null).also {
+                // Must be first — if another connection holds a lock, all subsequent
+                // PRAGMAs (including journal_mode) would throw immediately. Matches
+                // iOS's Database.swift#setWalMode (busy_timeout=5000, set first).
+                runPragma(it, "PRAGMA busy_timeout=5000")
                 runPragma(it, "PRAGMA journal_mode=WAL")
                 runPragma(it, "PRAGMA synchronous=NORMAL")  // FULL is too slow, NORMAL is safe with WAL
                 runPragma(it, "PRAGMA temp_store=MEMORY")   // Faster temp operations
@@ -39,6 +88,7 @@ class Database(private val name: String, private val context: Context) {
             openWithRetry {
                 SQLiteDatabase.openDatabase(databasePath, null, SQLiteDatabase.OPEN_READONLY).also {
                     try {
+                        runPragma(it, "PRAGMA busy_timeout=5000")
                         runPragma(it, "PRAGMA query_only=1")
                     } catch (_: Exception) {
                         // Best effort; some builds may not allow setting pragmas on read-only connections.
@@ -241,23 +291,35 @@ class Database(private val name: String, private val context: Context) {
     }
 
     fun transaction(function: () -> Unit) {
-        writerDb.beginTransaction()
-        incrementTransactionDepth()
-
+        // MOBILE-6492 (Tier 2): serialize against the native sync-apply path, which
+        // writes to this same file via acquireSqliteConnection() below, bypassing this
+        // method's own beginTransaction()/endTransaction() bookkeeping entirely.
+        // Mirrors iOS's Database.swift#inTransaction (writerTransactionSemaphore.wait()
+        // before beginTransaction(), signal() in the equivalent of `defer`).
+        writerTransactionSemaphore.acquire()
+        setWriterHolder("js-action")
         try {
-            function()
-            writerDb.setTransactionSuccessful()
-        } catch (e: SQLiteFullException) {
-            e.printStackTrace()
-            Log.e("watermelondb", "found this error ${e.localizedMessage}")
-            throw e
-        } finally {
+            writerDb.beginTransaction()
+            incrementTransactionDepth()
+
             try {
-                writerDb.endTransaction()
-            } catch (e: Exception) {
-                Log.e("watermelondb", "eee ${e.localizedMessage}")
+                function()
+                writerDb.setTransactionSuccessful()
+            } catch (e: SQLiteFullException) {
+                e.printStackTrace()
+                Log.e("watermelondb", "found this error ${e.localizedMessage}")
+                throw e
+            } finally {
+                try {
+                    writerDb.endTransaction()
+                } catch (e: Exception) {
+                    Log.e("watermelondb", "eee ${e.localizedMessage}")
+                }
+                decrementTransactionDepth()
             }
-            decrementTransactionDepth()
+        } finally {
+            clearWriterHolder()
+            writerTransactionSemaphore.release()
         }
     }
 

--- a/native/android/src/main/java/com/nozbe/watermelondb/Database.kt
+++ b/native/android/src/main/java/com/nozbe/watermelondb/Database.kt
@@ -15,6 +15,8 @@ import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Semaphore
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
 
 class Database(private val name: String, private val context: Context) {
 
@@ -35,7 +37,89 @@ class Database(private val name: String, private val context: Context) {
 
         internal fun writerTransactionSemaphoreFor(path: String): Semaphore =
             writerTransactionSemaphores.getOrPut(path) { Semaphore(1) }
+
+        // MOBILE-6492: how long a writer waits for the semaphore before giving up.
+        // Sized from the incident analysis: a real sync transaction holds the writer
+        // for 5-10s, so 30s leaves ample headroom for the legitimate case, while
+        // being far below the multi-minute wedge this bound exists to escape.
+        //
+        // A bound is mandatory, not defensive. `acquire()` never returns if a holder
+        // never releases — which is precisely the reported failure (a native
+        // sync-apply transaction orphaned by the ON_START foreground-cancel path,
+        // which resets bookkeeping without rolling back). Unbounded, that turns a
+        // visible `SQLiteDatabaseLockedException` into a silent, permanent stall of
+        // every writer on the file.
+        //
+        // `var` only so instrumented tests can shrink it; nothing in production
+        // reassigns it.
+        internal var writerSemaphoreTimeoutMs = 30_000L
+
+        // MOBILE-6492: reentrancy bookkeeping for the writer semaphore, keyed by
+        // database file, per thread.
+        //
+        // `transaction()` genuinely nests in production: DatabaseDriver.setUpSchema and
+        // .migrate both wrap `database.unsafeExecuteStatements(...)` inside their own
+        // `database.transaction { }`, and unsafeExecuteStatements transacts again.
+        // Semaphore(1) is NOT reentrant, so without this the inner frame waits on the
+        // permit its own thread is holding — an unbreakable self-deadlock on the two
+        // paths that must never hang: first-launch schema setup, and every migration.
+        //
+        // Per-thread is sound because all three writer paths acquire and release on one
+        // thread: JS transactions on the caller's thread, the native sync-apply inside a
+        // single OkHttp-callback invocation, and slice import on the single work-queue
+        // thread (SlicePlatformAndroid's gWorkThreadId) for both begin and commit.
+        private val writerDepths = object : ThreadLocal<MutableMap<String, Int>>() {
+            override fun initialValue(): MutableMap<String, Int> = HashMap()
+        }
+
+        // MOBILE-6492: writer-contention counters, per database file.
+        //
+        // These exist because the on-device issue report — the only artifact available
+        // for a field device — is written by the JS logger (`app/utils/logger`), and
+        // nothing anywhere captures logcat. So the Log.w this class emits on a timeout
+        // is invisible in exactly the artifact an investigation reads. A blast-radius
+        // sweep of 1,198 reports could establish who was failing but never who was
+        // *holding*, nor for how long.
+        //
+        // `maxWaitMs` is the load-bearing one: a successful acquire that waited N ms
+        // means some other writer held the file for ~N ms, which is a direct field
+        // measurement of real hold durations. Sustained values near
+        // `writerSemaphoreTimeoutMs` mean a genuinely wedged holder; values in the
+        // single-digit seconds mean ordinary transient contention.
+        //
+        // Read via DatabaseBridge.getWriterContentionStats so the app can fold them
+        // into its issue report.
+        private val writerStats = ConcurrentHashMap<String, WriterContentionStats>()
+
+        internal fun writerStatsFor(path: String): WriterContentionStats =
+            writerStats.getOrPut(path) { WriterContentionStats() }
+
+        // Anything above this is a real wait worth counting; below it is scheduler noise
+        // on an uncontended permit.
+        private const val CONTENDED_WAIT_THRESHOLD_MS = 50L
     }
+
+    internal class WriterContentionStats {
+        val contendedAcquires = AtomicLong(0)
+        val timeouts = AtomicLong(0)
+        val maxWaitMs = AtomicLong(0)
+
+        @Volatile
+        var lastTimeoutHolder: String? = null
+
+        fun recordWait(waitMs: Long) {
+            contendedAcquires.incrementAndGet()
+            // CAS loop: several writers can finish waiting concurrently, and a plain
+            // compare-then-set would let a smaller wait clobber a larger one.
+            while (true) {
+                val current = maxWaitMs.get()
+                if (waitMs <= current || maxWaitMs.compareAndSet(current, waitMs)) return
+            }
+        }
+    }
+
+    private val writerStatsForThisDb: WriterContentionStats
+        get() = writerStatsFor(databasePath)
 
     private val writerTransactionSemaphore: Semaphore
         get() = writerTransactionSemaphoreFor(databasePath)
@@ -50,18 +134,89 @@ class Database(private val name: String, private val context: Context) {
 
     internal fun currentWriterHolder(): String? = writerHolders[databasePath]
 
+    // MOBILE-6492: test-only view of the writer semaphore's permit count, so the
+    // permit-inflation regression test can assert the invariant (exactly one permit
+    // when idle) without widening access to the private database path.
+    internal fun availableWriterPermitsForTest(): Int =
+        writerTransactionSemaphore.availablePermits()
+
     // MOBILE-6492 (Tier 2): exposed for DatabaseBridge's JNI accessors, so the native
     // sync-apply path (JSIAndroidBridgeModule.cpp's ApplyCallback) can acquire/release
     // the same semaphore transaction() uses, around its own acquireSqliteConnection()/
     // applySyncPayload()/releaseSQLiteConnection() sequence — mirroring iOS's
     // JSISwiftWrapperModule.mm wait()/signal() around getRawConnection/applySyncPayload.
-    // Blocking — callers must invoke off the JS thread.
-    fun acquireWriterTransactionSemaphore() {
-        writerTransactionSemaphore.acquire()
+    //
+    // Reentrant, and blocks for at most `writerSemaphoreTimeoutMs`. Returns true if the
+    // caller now owns a frame and MUST pair it with releaseWriterTransactionSemaphore()
+    // — whether that frame took the permit outright or re-entered one this thread
+    // already holds. Returns false only on timeout, in which case the caller MUST NOT
+    // release: an unmatched release *raises* a binary Semaphore's permit count and
+    // silently voids mutual exclusion for the rest of the process's life.
+    fun acquireWriterTransactionSemaphore(holderName: String? = null): Boolean {
+        val depths = writerDepths.get()!!
+        val depth = depths[databasePath] ?: 0
+        if (depth > 0) {
+            // Nested frame on the thread that already owns the permit — must not touch
+            // the semaphore at all. See the writerDepths note above.
+            depths[databasePath] = depth + 1
+            return true
+        }
+        // Capture the holder BEFORE waiting: once we time out, whoever held the permit
+        // may already have released and been replaced, so reading it afterwards can
+        // name the wrong owner (or nobody).
+        val contendedBy = currentWriterHolder()
+        val startNs = System.nanoTime()
+        val acquired =
+            writerTransactionSemaphore.tryAcquire(writerSemaphoreTimeoutMs, TimeUnit.MILLISECONDS)
+        val waitedMs = (System.nanoTime() - startNs) / 1_000_000
+        val stats = writerStatsForThisDb
+
+        if (!acquired) {
+            stats.timeouts.incrementAndGet()
+            stats.lastTimeoutHolder = contendedBy ?: "unknown"
+            return false
+        }
+        if (waitedMs >= CONTENDED_WAIT_THRESHOLD_MS) {
+            stats.recordWait(waitedMs)
+        }
+
+        depths[databasePath] = 1
+        if (holderName != null) {
+            setWriterHolder(holderName)
+        }
+        return true
+    }
+
+    // MOBILE-6492: snapshot of the writer-contention counters for this database file.
+    // Cheap, allocation-light, and safe to call from any thread.
+    internal fun writerContentionSnapshot(): Map<String, Any> {
+        val stats = writerStatsForThisDb
+        return mapOf(
+            "contendedAcquires" to stats.contendedAcquires.get(),
+            "timeouts" to stats.timeouts.get(),
+            "maxWaitMs" to stats.maxWaitMs.get(),
+            "timeoutBoundMs" to writerSemaphoreTimeoutMs,
+            "lastTimeoutHolder" to (stats.lastTimeoutHolder ?: ""),
+            "currentHolder" to (currentWriterHolder() ?: "")
+        )
     }
 
     fun releaseWriterTransactionSemaphore() {
-        writerTransactionSemaphore.release()
+        val depths = writerDepths.get()!!
+        when (val depth = depths[databasePath] ?: 0) {
+            0 -> Log.w(
+                "watermelondb",
+                "releaseWriterTransactionSemaphore called without a held permit; " +
+                    "ignoring (releasing would inflate the permit count and void " +
+                    "writer mutual exclusion for this process)"
+            )
+            1 -> {
+                depths.remove(databasePath)
+                clearWriterHolder()
+                writerTransactionSemaphore.release()
+            }
+            else -> depths[databasePath] = depth - 1
+        }
     }
 
     private val writerDb: SQLiteDatabase by lazy {
@@ -296,8 +451,22 @@ class Database(private val name: String, private val context: Context) {
         // method's own beginTransaction()/endTransaction() bookkeeping entirely.
         // Mirrors iOS's Database.swift#inTransaction (writerTransactionSemaphore.wait()
         // before beginTransaction(), signal() in the equivalent of `defer`).
-        writerTransactionSemaphore.acquire()
-        setWriterHolder("js-action")
+        //
+        // Bounded, unlike iOS's unconditional wait(): on timeout we proceed WITHOUT the
+        // permit and let `PRAGMA busy_timeout` (Tier 1) arbitrate at the SQLite layer.
+        // That deliberately degrades to the pre-Tier-2 behaviour — a possible
+        // SQLiteDatabaseLockedException — rather than stalling this writer forever
+        // behind a holder that may never release. Serialization is an optimization
+        // here; never hanging is a correctness requirement.
+        val acquired = acquireWriterTransactionSemaphore("js-action")
+        if (!acquired) {
+            Log.w(
+                "watermelondb",
+                "writer semaphore timed out after ${writerSemaphoreTimeoutMs}ms " +
+                    "(holder=${currentWriterHolder() ?: "unknown"}); proceeding " +
+                    "unserialized — busy_timeout will arbitrate"
+            )
+        }
         try {
             writerDb.beginTransaction()
             incrementTransactionDepth()
@@ -318,8 +487,13 @@ class Database(private val name: String, private val context: Context) {
                 decrementTransactionDepth()
             }
         } finally {
-            clearWriterHolder()
-            writerTransactionSemaphore.release()
+            // Only unwind a frame we actually entered. Releasing after a timed-out
+            // acquire would inflate the permit count; and release() itself decides
+            // whether this is the outermost frame, so the holder name survives for the
+            // duration of a nested transaction.
+            if (acquired) {
+                releaseWriterTransactionSemaphore()
+            }
         }
     }
 

--- a/native/android/src/main/java/com/nozbe/watermelondb/DatabaseBridge.kt
+++ b/native/android/src/main/java/com/nozbe/watermelondb/DatabaseBridge.kt
@@ -403,6 +403,32 @@ class DatabaseBridge(private val reactContext: ReactApplicationContext) :
         }
     }
 
+    // MOBILE-6492 (Tier 2): JNI-callable accessors for the native sync-apply path
+    // (JSIAndroidBridgeModule.cpp's ApplyCallback) to serialize against JS-driven
+    // Database.kt#transaction() writes on the same underlying file. Mirrors iOS's
+    // DatabaseBridge.swift getWriterTransactionSemaphore/setWriterHolder/
+    // clearWriterHolder accessors used by JSISwiftWrapperModule.mm.
+    //
+    // Blocking call — must be invoked off the JS thread (the native sync-apply path
+    // already runs on OkHttp's callback thread, never the JS thread).
+    fun acquireWriterTransactionSemaphore(tag: ConnectionTag, holderName: String) {
+        val driver = getDriver(tag)
+        val database = driver.getDatabase()
+        database.acquireWriterTransactionSemaphore()
+        database.setWriterHolder(holderName)
+    }
+
+    fun releaseWriterTransactionSemaphore(tag: ConnectionTag) {
+        try {
+            val driver = getDriver(tag)
+            val database = driver.getDatabase()
+            database.clearWriterHolder()
+            database.releaseWriterTransactionSemaphore()
+        } catch (e: Exception) {
+            android.util.Log.e("WatermelonDB", "releaseWriterTransactionSemaphore failed for tag $tag", e)
+        }
+    }
+
     fun getSQLiteReadConnection(tag: ConnectionTag): Long {
         try {
             val driver = getDriver(tag)

--- a/native/android/src/main/java/com/nozbe/watermelondb/DatabaseBridge.kt
+++ b/native/android/src/main/java/com/nozbe/watermelondb/DatabaseBridge.kt
@@ -409,20 +409,85 @@ class DatabaseBridge(private val reactContext: ReactApplicationContext) :
     // DatabaseBridge.swift getWriterTransactionSemaphore/setWriterHolder/
     // clearWriterHolder accessors used by JSISwiftWrapperModule.mm.
     //
-    // Blocking call — must be invoked off the JS thread (the native sync-apply path
-    // already runs on OkHttp's callback thread, never the JS thread).
-    fun acquireWriterTransactionSemaphore(tag: ConnectionTag, holderName: String) {
-        val driver = getDriver(tag)
-        val database = driver.getDatabase()
-        database.acquireWriterTransactionSemaphore()
-        database.setWriterHolder(holderName)
+    // Blocking call, bounded by Database.writerSemaphoreTimeoutMs — must be invoked off
+    // the JS thread (the native sync-apply path already runs on OkHttp's callback
+    // thread, never the JS thread).
+    //
+    // Returns true only if the permit was actually taken; the caller must release iff
+    // it got true. Every failure path returns false rather than throwing across the
+    // JNI boundary: a Java exception here would be swallowed by the caller's
+    // ExceptionClear(), leaving it to "release" a permit it never held — which raises
+    // the binary semaphore's permit count and silently voids mutual exclusion for the
+    // remaining life of the process.
+    fun acquireWriterTransactionSemaphore(tag: ConnectionTag, holderName: String): Boolean {
+        return try {
+            val database = getDriver(tag).getDatabase()
+            // Pass the holder through — Database records it only for the outermost
+            // frame, so a nested acquire can't overwrite the real owner's name.
+            val acquired = database.acquireWriterTransactionSemaphore(holderName)
+            if (!acquired) {
+                android.util.Log.w(
+                    "WatermelonDB",
+                    "acquireWriterTransactionSemaphore timed out for tag $tag " +
+                        "(holder=${database.currentWriterHolder() ?: "unknown"}, " +
+                        "requester=$holderName)"
+                )
+            }
+            acquired
+        } catch (e: Exception) {
+            android.util.Log.e(
+                "WatermelonDB",
+                "acquireWriterTransactionSemaphore failed for tag $tag",
+                e
+            )
+            false
+        }
+    }
+
+    /**
+     * MOBILE-6492: writer-contention counters for this connection's database file.
+     *
+     * Exists so the app can fold them into its on-device issue report. That report is
+     * assembled from the JS logger and captures no logcat, so `Database`'s own
+     * `Log.w` on a semaphore timeout never reaches the one artifact a field
+     * investigation can read — which is why the blast-radius sweep could identify
+     * which call sites were *failing* but never which writer was *holding*.
+     *
+     * `maxWaitMs` is the field measurement that matters: it is how long a writer
+     * actually waited before succeeding, i.e. how long some other writer held the
+     * file. Values near `timeoutBoundMs` indicate a wedged holder; single-digit
+     * seconds indicate ordinary transient contention.
+     *
+     * Android-only for now — the app must guard the call (the iOS bridge has no
+     * counterpart yet), and nothing consumes it inside this package.
+     */
+    @ReactMethod
+    fun getWriterContentionStats(tag: ConnectionTag, promise: Promise) {
+        try {
+            val snapshot = getDriver(tag).getDatabase().writerContentionSnapshot()
+            val map = Arguments.createMap()
+            snapshot.forEach { (key, value) ->
+                when (value) {
+                    is Long -> map.putDouble(key, value.toDouble())
+                    is Int -> map.putInt(key, value)
+                    else -> map.putString(key, value.toString())
+                }
+            }
+            promise.resolve(map)
+        } catch (e: Exception) {
+            // Diagnostics must never break a caller. An unavailable connection is an
+            // expected outcome here, not an error worth rejecting on.
+            android.util.Log.w("WatermelonDB", "getWriterContentionStats failed for tag $tag", e)
+            promise.resolve(null)
+        }
     }
 
     fun releaseWriterTransactionSemaphore(tag: ConnectionTag) {
         try {
             val driver = getDriver(tag)
             val database = driver.getDatabase()
-            database.clearWriterHolder()
+            // No explicit clearWriterHolder() — release() clears it on the outermost
+            // frame only, so clearing here would wipe the owner mid-nesting.
             database.releaseWriterTransactionSemaphore()
         } catch (e: Exception) {
             android.util.Log.e("WatermelonDB", "releaseWriterTransactionSemaphore failed for tag $tag", e)


### PR DESCRIPTION
## Summary

Android has no serialization between the three code paths that write to the same SQLite
writer connection: JS-driven writes (`Database.kt#transaction`), the native sync-apply path
(`JSIAndroidBridgeModule.cpp`'s `ApplyCallback`), and the slice-import writer
(`SliceImportDatabaseAdapterAndroid.cpp`). Under contention this surfaces to users as
`SQLiteDatabaseLockedException` ("database is locked", code 5) — reported in SIP-16015 as a
~9-minute continuous lock that survived a full JS re-init on a production device.

- **Tier 1** — set `PRAGMA busy_timeout=5000` on both `writerDb` and `readerDb` (first,
  before any other pragma). Fixes the common transient two-connection collision case.
  Matches iOS's `Database.swift#setWalMode`.
- **Tier 2** — port iOS's `writerTransactionSemaphore` (`Database.swift:59`) to Android: a
  per-database-file binary semaphore acquired/released around all three writer paths above.
- **Tier 2 hardening** (second commit) — reentrancy, a bounded wait, an acquire that reports
  success, an RAII guard, and contention instrumentation. Details below; the first three fix
  defects in Tier 2 as originally authored, one of which hung the app on launch.

## Root cause detail

- `JSIAndroidBridgeModule.cpp` (Android's TurboModule, the analog of iOS's
  `JSISwiftWrapperModule.mm`) wires `SyncEngine`'s `ApplyCallback` to acquire the raw
  `sqlite3*` via JNI reflection into `Database.kt`'s own `writerDb`, call the shared
  `watermelondb::applySyncPayload()` free function (raw `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK`
  via `sqlite3_exec`), then release — entirely outside `Database.kt#transaction()`'s
  bookkeeping.
- That means **two incompatible transaction schemes share one connection**: raw
  `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK` on the C++ side, and requery's
  `beginTransaction()`/`endTransaction()` (which maintains its own nesting state in
  `SQLiteSession`) on the Kotlin side. Interleaving them can desync the two, leaving a
  `BEGIN` with no matching terminator — a live connection stuck in a transaction, which
  survives a JS re-init and clears only on process death. That is the mechanism serialization
  prevents: it stops the wedge from being *created*, rather than rescuing one that exists.
- `BackgroundSyncBridge`'s `ON_START` foreground observer calls `SyncEngine::cancelSync()`,
  which only resets C++ bookkeeping under a mutex. `handleHttpResponse` checks
  `syncId != syncId_` **before** invoking `applyCb`, and `SyncApplyEngine.cpp` has no
  cancellation hook at all — so once `BEGIN IMMEDIATE` has started, foreground cancellation
  is structurally incapable of stopping it.
- iOS never hits this because `writerTransactionSemaphore` already guards all three of its
  equivalent paths (`inTransaction()`, `executeStandalone`/`executeStatementsStandalone`,
  `JSISwiftWrapperModule.mm`'s `ApplyCallback`, and `SliceImportDatabaseAdapter.mm`'s
  `beginTransaction`). Android had zero synchronization primitives protecting the SQLite
  writer.

## Tier 2 hardening — three defects fixed

**1. Nested `transaction()` self-deadlocked (release-blocking).** `DatabaseDriver.kt:341`
(`setUpSchema`) and `:353` (`migrate`) both wrap `database.unsafeExecuteStatements(...)` in
their own `database.transaction { }`, and `unsafeExecuteStatements` (`Database.kt:250`) is
itself a `transaction { }`. `Semaphore(1)` is not reentrant, so the inner frame waited on the
permit its own thread was holding. Those two call sites are **first-launch schema setup and
every migration** — as originally authored this hung the app on launch and on upgrade. Fixed
with per-(thread, database file) reentrancy depth, which is sound because all three writer
paths acquire and release on a single thread (JS on the caller's thread, native sync-apply
inside one OkHttp-callback invocation, slice import on `SlicePlatformAndroid`'s single
`gWorkThreadId` for both begin and commit).

**2. An unmatched release could silently void mutual exclusion.** `acquireWriterSemaphore`
returned `void` with three silent JNI failure paths (`!env || !bridge`, `!cls`, missing
methodID), and the Kotlin accessor had no `try/catch`, so a Java-side throw was swallowed by
the caller's `ExceptionClear()`. The caller then released a permit it never held, raising
`Semaphore(1)` to 2 and **disabling Tier 2 entirely while every test still passed**. Acquire
now reports success (`Boolean`/`bool`, JNI descriptor `)Z`), callers release only on true, and
release refuses at depth 0 so inflation is structurally impossible rather than dependent on
caller discipline.

**3. Unbounded `acquire()` could stall a writer forever.** Against a holder that never
releases — the reported failure mode — an unbounded wait turns a visible
`SQLiteDatabaseLockedException` into a *permanent silent stall* of every writer on the file.
Now `tryAcquire` with a 30s bound (sized against the 5-10s a real sync transaction holds);
on expiry we log the holder and proceed unserialized so `busy_timeout` arbitrates. It never
hangs, and the worst case matches pre-Tier-2 behaviour instead of being worse than it.

Also replaces the manual release calls around the native sync-apply with an RAII guard, so no
early return or exception can leak or double-release the permit.

## Instrumentation

Writer-contention counters per database file — `maxWaitMs`, `timeouts`, `lastTimeoutHolder`,
`contendedAcquires`, `timeoutBoundMs` — exposed via
`DatabaseBridge.getWriterContentionStats`.

This exists because a blast-radius sweep of **1,198 production issue reports** (Aug 17-19)
could establish which call sites were *failing* but never which writer was *holding*, nor for
how long: the on-device report is assembled from the JS logger (`app/utils/logger`) and
nothing anywhere captures logcat, so `Database.kt`'s `Log.w` never reaches the one artifact a
field investigation can read. `maxWaitMs` is the load-bearing metric — a successful acquire
that waited N ms means another writer held the file for ~N ms, which is a direct field
measurement of real hold durations, and is what distinguishes a wedged holder from ordinary
transient contention.

Android-only for now; the iOS bridge has no counterpart, so the app must guard the call.
Nothing consumes it yet — the app-side pickup is a small follow-up.

## Blast-radius data (MOBILE-6492 item 6)

Swept via the Datadog `mobile-issue-reports` service (env `prod`), which ingests the
on-device error reports. Retention only covers **Aug 17-19**; `online-archives` returns
nothing for July, so the original SIP-16015 device is out of reach.

| Metric | Value |
|---|---|
| Total issue reports | 1,198 |
| Containing `"database is locked"` | **11 (0.92%)** |
| Distinct users / tenants | **7 / 7** |
| Platform | **100% Android**, OS 10 / 13 / 16 / 17, apps 3.77.0-3.79.0 |
| Reports touching `handleVisitAction` | **0** |

Two things this changes:

- The ticket's *"Android 16 / this Samsung device family"* suspicion **does not hold** as a
  concentrating factor — the signature spans Android 10 through 17 and three app versions.
- **Zero** of the 11 reached `VisitActions.handleVisitAction`, the call site that produced
  SIP-16015's user-facing "Travel failed" symptom. Every occurrence is a sync path
  (`sync-coordinator`, `syncDatabase`, `JobTaskSync`), i.e. invisible to the technician. All
  three of those route through `database.action`/batch → `DatabaseDriver.kt:252
  database.transaction { }` → this semaphore, so Tier 2 does cover what is actually failing
  in the field.

## Test plan

- [x] Full `DatabaseTest` suite: **21/21 passing**, no regressions, on a Pixel 6 API 36
      emulator (arm64-v8a), via `./gradlew :watermelondb:connectedDebugAndroidTest
      -Pandroid.testInstrumentationRunnerArguments.class=com.nozbe.watermelondb.DatabaseTest`
- [x] `nestedTransactionDoesNotSelfDeadlock` — reproduces the `setUpSchema`/`migrate` nesting
      shape. Verified to fail with reentrancy disabled (`took 1510ms — it waited out the
      semaphore bound instead of re-entering`); under the original unbounded `acquire()` that
      1510ms is unbounded.
- [x] `wedgedHolderDoesNotBlockSecondWriterForever` — a holder that genuinely never releases.
      Asserts liveness (the writer returns within the bound), not success.
- [x] `failedAcquireDoesNotInflatePermits` — a contending thread's acquire must report false
      and must not inflate the permit count.
- [x] `writerContentionStatsRecordHolderAndWaitDuration` — pins the holder named at timeout
      and `maxWaitMs` against a real 400ms hold. Verified to fail with recording disabled
      (`maxWaitMs should reflect the ~400ms hold, got 0ms`).
- [x] Pre-existing Tier 1/2 tests unchanged and still green:
      `alreadyOpenConnectionWaitsOnBusyInsteadOfThrowing` (4.0s),
      `orphanedHolderBlocksSecondWriterUntilReleaseInsteadOfThrowing` (7.0s),
      `concurrentWritersWithBusyTimeoutDoNotThrow` (4.1s).

### Compilation status — read this before trusting a "compile-verified" claim

An earlier revision of this description said the C++ was compile-verified across all four
ABIs. **That does not hold**, and the correction matters:

- Gradle's `externalNativeBuildDebug` reports SUCCESS **without invoking the compiler**.
  Demonstrated by appending a syntax error to `JSIAndroidBridgeModule.cpp` and still getting
  `BUILD SUCCESSFUL`; ninja independently reported 16 pending steps and zero object files.
- Compiling with ninja directly: `SliceImportDatabaseAdapterAndroid.cpp` **builds clean**
  (arm64-v8a), but `JSIAndroidBridgeModule.cpp` **cannot be compiled by this repo's harness at
  all** — `fatal error: 'WatermelonDBSpecJSI.h' file not found`, a React Native codegen
  artifact that only exists during a full new-arch app build.
- So the `JSIAndroidBridgeModule.cpp` edits (both tiers') are reviewed and
  JNI-descriptor-checked but **not compiler-checked**. Verifying them requires an android
  build of the consuming app. Tracked as MOBILE-6492 item 3.
- Gradle also reported `compileDebugKotlin UP-TO-DATE` on genuinely modified sources — this
  harness's incremental state is not trustworthy; use `--rerun-tasks`.

- [ ] Functional verification of the native sync-apply and slice-import paths under real
      contention — needs the app-level build above (MOBILE-6492 item 3).

## Deliberately out of scope (tracked as follow-ups on MOBILE-6492)

- **Item 4** — making the background-sync cancel path safe: thread a `shouldAbort` predicate
  into `applySyncPayload` (checked at page/batch boundaries, ROLLBACK on abort) and override
  `onStopped()` in `BackgroundSyncWorker`, which today has none, so WorkManager cancellation
  unwinds the coroutine while the native apply keeps running. Deliberately separate: it
  touches `native/shared/`, which iOS also compiles.
- **Item 5** — wedged-lock self-healing. Lower priority than originally scoped: if the wedge
  is created by interleaving and clears on process death, Tier 2 prevents creation and item 5
  only buys within-session recovery. Gate it on field data from the new counters.
- The app-side pickup of `getWriterContentionStats` into the issue report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168BAzQbmWnhduQht3WNEYC
