### PR TITLE
fix(sync): route a 200 auth-error envelope into re-auth instead of crashing - MOBILE-6770

### DIFF
--- a/native/shared/SyncEngine.cpp
+++ b/native/shared/SyncEngine.cpp
@@ -239,6 +239,16 @@ bool extractNextCursor(const std::string& body, CursorValue& cursorOut) {
 // "items" (not an "errors" array with an auth code), so this returns false for the
 // happy path, and false for non-JSON / non-object bodies.
 bool isAuthErrorEnvelope(const std::string& body) {
+    // Hot-path guard: this runs under the engine mutex for every 2xx response,
+    // including large successful pulls. An auth error envelope always carries a
+    // top-level "errors" array; a successful sync payload ({"items":...} /
+    // {"changes":...}) never does. Skip the full JSON parse entirely unless the
+    // body even contains an "errors" key, so the successful-pull path stays
+    // parse-free (a rare payload that mentions "errors" in data does one extra
+    // parse and still resolves to false — correct, just not free).
+    if (body.find("\"errors\"") == std::string::npos) {
+        return false;
+    }
     try {
         simdjson::dom::parser parser;
         simdjson::dom::element doc = parser.parse(body);

--- a/native/shared/SyncEngine.cpp
+++ b/native/shared/SyncEngine.cpp
@@ -240,12 +240,17 @@ bool extractNextCursor(const std::string& body, CursorValue& cursorOut) {
 // happy path, and false for non-JSON / non-object bodies.
 bool isAuthErrorEnvelope(const std::string& body) {
     // Hot-path guard: this runs under the engine mutex for every 2xx response,
-    // including large successful pulls. An auth error envelope always carries a
-    // top-level "errors" array; a successful sync payload ({"items":...} /
-    // {"changes":...}) never does. Skip the full JSON parse entirely unless the
-    // body even contains an "errors" key, so the successful-pull path stays
-    // parse-free (a rare payload that mentions "errors" in data does one extra
-    // parse and still resolves to false — correct, just not free).
+    // including large successful pulls. An auth error envelope is tiny (mobile-api's
+    // TOKEN_EXPIRED/REQUEST_IGNORED envelopes are <1KB) and always carries a
+    // top-level "errors" array; a successful sync payload is orders of magnitude
+    // larger and has no "errors" key. Bail in O(1) on size FIRST so a large pull is
+    // never scanned or parsed on the hot path regardless of its contents, then
+    // require an "errors" key before the (small-body) structured parse. A body
+    // larger than any plausible auth envelope cannot be one.
+    constexpr size_t kMaxAuthEnvelopeBytes = 8192;
+    if (body.size() > kMaxAuthEnvelopeBytes) {
+        return false;
+    }
     if (body.find("\"errors\"") == std::string::npos) {
         return false;
     }

--- a/native/shared/SyncEngine.cpp
+++ b/native/shared/SyncEngine.cpp
@@ -231,6 +231,56 @@ bool extractNextCursor(const std::string& body, CursorValue& cursorOut) {
     }
 }
 
+// MOBILE-6770: mobile-api returns an expired/invalid token as HTTP 200 with a
+// GraphQL-style error envelope {"errors":[{"extensions":{"code":"TOKEN_EXPIRED"}}],...}
+// that has no top-level "items". Detect that shape so handleHttpResponse can route
+// it into the existing re-auth path instead of letting it fall through to apply and
+// throw "Invalid JSON payload: missing 'items' array". A valid sync payload carries
+// "items" (not an "errors" array with an auth code), so this returns false for the
+// happy path, and false for non-JSON / non-object bodies.
+bool isAuthErrorEnvelope(const std::string& body) {
+    try {
+        simdjson::dom::parser parser;
+        simdjson::dom::element doc = parser.parse(body);
+        if (doc.type() != simdjson::dom::element_type::OBJECT) {
+            return false;
+        }
+        simdjson::dom::object obj;
+        if (doc.get(obj)) {
+            return false;
+        }
+        auto errorsField = obj["errors"];
+        if (errorsField.error()) {
+            return false;
+        }
+        simdjson::dom::array errors;
+        if (errorsField.value().get(errors)) {
+            return false;
+        }
+        for (simdjson::dom::element err : errors) {
+            auto extField = err["extensions"];
+            if (extField.error()) {
+                continue;
+            }
+            auto codeField = extField.value()["code"];
+            if (codeField.error()) {
+                continue;
+            }
+            std::string_view code;
+            if (codeField.value().get(code)) {
+                continue;
+            }
+            if (code == "TOKEN_EXPIRED" || code == "UNAUTHENTICATED" ||
+                code == "UNAUTHORIZED") {
+                return true;
+            }
+        }
+        return false;
+    } catch (...) {
+        return false;
+    }
+}
+
 } // namespace
 
 SyncEngine::SyncEngine() = default;
@@ -644,7 +694,16 @@ void SyncEngine::handleHttpResponse(int64_t syncId, const platform::HttpResponse
             shouldReturn = true;
         }
 
-        if (response.statusCode == 401 || response.statusCode == 403) {
+        // MOBILE-6770: an expired/invalid token can also arrive as HTTP 200 with an
+        // auth error envelope (no "items"). Route it into the same re-auth path as a
+        // 401/403 so the native pull recovers instead of falling through to apply and
+        // crashing. Only the native pull path reaches this branch — the JS axios client
+        // already handles the 200 envelope via its response interceptor.
+        const bool isAuthFailure =
+            response.statusCode == 401 || response.statusCode == 403 ||
+            (response.statusCode >= 200 && response.statusCode < 300 &&
+             isAuthErrorEnvelope(response.body));
+        if (isAuthFailure) {
             if (authRetryCount_ >= maxAuthRetries_) {
                 // Auth retries exhausted
                 emitLocked("{\"type\":\"auth_failed\",\"message\":\"Max auth retries exceeded\"}");

--- a/native/shared/tests/SyncEngineTests.cpp
+++ b/native/shared/tests/SyncEngineTests.cpp
@@ -192,6 +192,41 @@ void test_auth_error_envelope_200_reauths_and_completes() {
                "expected sync to recover to done after a 200 auth-error envelope");
 }
 
+void test_large_payload_200_not_treated_as_auth() {
+    // MOBILE-6770 hot-path guard: a large successful pull (no top-level "errors")
+    // must complete normally and never be treated as an auth envelope. The envelope
+    // check short-circuits on the missing "errors" key, so no full parse of the
+    // payload happens under the mutex.
+    EventRecorder recorder;
+    auto engine = std::make_shared<watermelondb::SyncEngine>();
+    engine->setEventCallback([&](const std::string& eventJson) { recorder.add(eventJson); });
+    engine->setApplyCallback([&](const std::string&, std::string&, watermelondb::SyncChangeset&) { return true; });
+
+    // ~250KB payload with items and no "errors"/auth markers.
+    std::string body = "{\"changes\":{\"records\":[";
+    for (int i = 0; i < 5000; i++) {
+        if (i > 0) {
+            body += ",";
+        }
+        body += "{\"id\":\"rec-" + std::to_string(i) + "\",\"name\":\"sample record value\"}";
+    }
+    body += "]},\"next\":null}";
+
+    watermelondb::platform::setHttpHandler([body](const watermelondb::platform::HttpRequest&,
+                                                  std::function<void(const watermelondb::platform::HttpResponse&)> done) {
+        watermelondb::platform::HttpResponse response;
+        response.statusCode = 200;
+        response.body = body;
+        done(response);
+    });
+
+    engine->configure("{\"pullEndpointUrl\":\"https://example.com/pull\",\"connectionTag\":1}");
+    engine->start("large-payload");
+
+    expectTrue(recorder.waitForContains("\"state\":\"done\""),
+               "expected a large 200 payload to complete, not be treated as auth");
+}
+
 void test_retry_flow() {
     EventRecorder recorder;
     auto engine = std::make_shared<watermelondb::SyncEngine>();
@@ -1188,6 +1223,7 @@ int main() {
     test_auth_required();
     test_auth_error_envelope_200_routes_to_auth_required();
     test_auth_error_envelope_200_reauths_and_completes();
+    test_large_payload_200_not_treated_as_auth();
     test_retry_flow();
     test_cursor_pagination();
     test_changeset_accumulates_across_pages();

--- a/native/shared/tests/SyncEngineTests.cpp
+++ b/native/shared/tests/SyncEngineTests.cpp
@@ -193,10 +193,10 @@ void test_auth_error_envelope_200_reauths_and_completes() {
 }
 
 void test_large_payload_200_not_treated_as_auth() {
-    // MOBILE-6770 hot-path guard: a large successful pull (no top-level "errors")
-    // must complete normally and never be treated as an auth envelope. The envelope
-    // check short-circuits on the missing "errors" key, so no full parse of the
-    // payload happens under the mutex.
+    // MOBILE-6770 hot-path guard: a large successful pull must complete normally and
+    // never be treated as an auth envelope. The envelope check bails in O(1) on the
+    // body size (this ~250KB payload is far above the auth-envelope cap), so no scan
+    // or parse of the payload happens under the mutex.
     EventRecorder recorder;
     auto engine = std::make_shared<watermelondb::SyncEngine>();
     engine->setEventCallback([&](const std::string& eventJson) { recorder.add(eventJson); });

--- a/native/shared/tests/SyncEngineTests.cpp
+++ b/native/shared/tests/SyncEngineTests.cpp
@@ -125,6 +125,73 @@ void test_auth_required() {
     expectTrue(recorder.waitForContains("\"type\":\"auth_required\""), "expected auth_required event");
 }
 
+void test_auth_error_envelope_200_routes_to_auth_required() {
+    // MOBILE-6770: mobile-api returns an expired/invalid token as HTTP 200 with a
+    // GraphQL-style auth error envelope (no top-level "items"). The native pull
+    // path must route it into the same re-auth flow as a 401 rather than falling
+    // through to apply and throwing "Invalid JSON payload: missing 'items' array".
+    EventRecorder recorder;
+    auto engine = std::make_shared<watermelondb::SyncEngine>();
+    engine->setEventCallback([&](const std::string& eventJson) { recorder.add(eventJson); });
+    engine->setApplyCallback([&](const std::string&, std::string&, watermelondb::SyncChangeset&) { return true; });
+
+    watermelondb::platform::setHttpHandler([](const watermelondb::platform::HttpRequest&,
+                                              std::function<void(const watermelondb::platform::HttpResponse&)> done) {
+        watermelondb::platform::HttpResponse response;
+        response.statusCode = 200;
+        response.body =
+            "{\"errors\":[{\"message\":\"jwt expired\",\"extensions\":{\"code\":\"TOKEN_EXPIRED\"}}],\"data\":{}}";
+        done(response);
+    });
+
+    engine->configure("{\"pullEndpointUrl\":\"https://example.com/pull\",\"connectionTag\":1}");
+    engine->start("auth-200-envelope");
+
+    expectTrue(recorder.waitForContains("\"type\":\"auth_required\""),
+               "expected auth_required event for a 200 auth-error envelope");
+}
+
+void test_auth_error_envelope_200_reauths_and_completes() {
+    // MOBILE-6770: after a 200 auth-error envelope routes to re-auth, a refreshed
+    // token must let the retried pull complete — i.e. the sync recovers, it does not
+    // just surface auth_required and wedge.
+    EventRecorder recorder;
+    auto engine = std::make_shared<watermelondb::SyncEngine>();
+    engine->setEventCallback([&](const std::string& eventJson) { recorder.add(eventJson); });
+    engine->setApplyCallback([&](const std::string&, std::string&, watermelondb::SyncChangeset&) { return true; });
+
+    engine->setAuthTokenRequestCallback([engine]() { engine->setAuthToken("token-2"); });
+    engine->setAuthToken("token-1");
+
+    static int envCallCount = 0;
+    envCallCount = 0;
+    watermelondb::platform::setHttpHandler([&](const watermelondb::platform::HttpRequest& request,
+                                               std::function<void(const watermelondb::platform::HttpResponse&)> done) {
+        watermelondb::platform::HttpResponse response;
+        if (envCallCount == 0) {
+            // Expired token surfaces as a 200 auth-error envelope (no "items").
+            response.statusCode = 200;
+            response.body =
+                "{\"errors\":[{\"extensions\":{\"code\":\"TOKEN_EXPIRED\"}}],\"data\":{}}";
+        } else {
+            // After re-auth, the retried pull gets a real (empty) sync payload.
+            response.statusCode = 200;
+            response.body = "{\"changes\":{},\"next\":null}";
+            auto authIt = request.headers.find("Authorization");
+            expectTrue(authIt != request.headers.end() && authIt->second == "token-2",
+                       "expected refreshed auth token on retry after 200 auth envelope");
+        }
+        envCallCount++;
+        done(response);
+    });
+
+    engine->configure("{\"pullEndpointUrl\":\"https://example.com/pull\",\"connectionTag\":1}");
+    engine->start("auth_200_recover");
+
+    expectTrue(recorder.waitForContains("\"state\":\"done\""),
+               "expected sync to recover to done after a 200 auth-error envelope");
+}
+
 void test_retry_flow() {
     EventRecorder recorder;
     auto engine = std::make_shared<watermelondb::SyncEngine>();
@@ -1119,6 +1186,8 @@ void test_shutdown_calls_completion() {
 int main() {
     test_success_flow();
     test_auth_required();
+    test_auth_error_envelope_200_routes_to_auth_required();
+    test_auth_error_envelope_200_reauths_and_completes();
     test_retry_flow();
     test_cursor_pagination();
     test_changeset_accumulates_across_pages();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "7.0.4-33",
+  "version": "7.0.4-34",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "7.0.4-32",
+  "version": "7.0.4-33",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "7.0.4-31",
+  "version": "7.0.4-32",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",


### PR DESCRIPTION
## What

The native Nitro sync engine crashes with `Invalid JSON payload: missing 'items' array` when mobile-api returns an expired/invalid token as **HTTP 200** with a GraphQL error-envelope (`{"errors":[{"extensions":{"code":"TOKEN_EXPIRED"}}],"data":{}}`) that has no top-level `items`. The native engine makes the pull HTTP call in native code, bypassing the JS axios interceptor that already handles this envelope — so it only affects the Nitro path (MOBILE-6770, the second trigger of MOBILE-6204).

## Change (`native/shared/SyncEngine.cpp`)

- New `isAuthErrorEnvelope()` simdjson helper (modeled on `extractNextCursor`) — true iff the body is a JSON object with an `errors` array carrying an auth code (`TOKEN_EXPIRED` / `UNAUTHENTICATED` / `UNAUTHORIZED`).
- `handleHttpResponse` folds a 2xx-with-auth-envelope into the existing auth-failure branch (`isAuthFailure = 401 || 403 || (2xx && isAuthErrorEnvelope)`), routing it into the existing `auth_required → re-auth → restart` path — exactly like a 401/403. A normal payload (`items`, no `errors`) and the 304 no-op path are unchanged.

## Why client-side (not a server change)

The server's HTTP-200 error-envelope is a contract the JS/axios client and every other consumer already handle (silent refresh+retry). **Only** the native engine can't parse it. A server-side 401 would change behavior for all non-Nitro clients — including an `/auth/check` → sign-out overlay regression and ~40 other REST call-site shifts — to fix a bug only the Nitro path has. So the fix belongs here.

## Tests (`native/shared/tests/SyncEngineTests.cpp`)

- `test_auth_error_envelope_200_routes_to_auth_required` — 200 envelope → `auth_required` (RED before the fix; verified).
- `test_auth_error_envelope_200_reauths_and_completes` — 200 envelope → refreshed token → `done` (end-to-end recovery).
- Full `yarn test:cpp` suite green; `yarn typecheck` green.

Published as prerelease **`7.0.4-32`** (dist-tag `next`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKSAWxdHZcsDDL5dpoHSFg
