### PR TITLE
fix(sync): bound the re-auth loop, progress-aware (7.0.4-36) - MOBILE-6770

### DIFF
--- a/native/shared/SyncEngine.cpp
+++ b/native/shared/SyncEngine.cpp
@@ -381,7 +381,12 @@ void SyncEngine::setAuthToken(const std::string& token) {
         authToken_ = token;
 
         authRequestInFlight_ = false;
-        authRetryCount_ = 0; // Reset auth retry count on successful token
+        // MOBILE-6770: do NOT reset the auth-retry budget merely because a token was
+        // fetched. If the server keeps rejecting the fetched token (a persistent 401
+        // or a 200 auth-error envelope), resetting here would let the re-auth loop run
+        // forever — a per-device retry storm (cf. MOBILE-6786). The budget is
+        // replenished only by a genuinely new sync (see start()) or a cancel, so a
+        // persistent auth failure now terminates at auth_failed after maxAuthRetries.
 
         if (!syncInFlight_ && stateJson_ == "{\"state\":\"auth_required\"}") {
             shouldRestart = true;
@@ -446,12 +451,18 @@ void SyncEngine::startWithCompletion(const std::string& reason, CompletionCallba
             syncInFlight_ = true;
             retryScheduled_ = false;
             retryCount_ = 0;
-            authRetryCount_ = 0; // Reset auth retry count on new sync
+            // MOBILE-6770: only a genuinely new sync replenishes the auth-retry budget.
+            // An auth-driven restart (resumeFromAuth) must NOT reset it, or a persistent
+            // server auth-rejection would re-auth forever instead of terminating at
+            // auth_failed after maxAuthRetries cycles.
+            const bool resumeFromAuth = (stateJson_ == "{\"state\":\"auth_required\"}") && !currentPullUrl_.empty();
+            if (!resumeFromAuth) {
+                authRetryCount_ = 0;
+            }
             currentReason_ = reason;
             if (completion) {
                 completionCallback_ = std::move(completion);
             }
-            const bool resumeFromAuth = (stateJson_ == "{\"state\":\"auth_required\"}") && !currentPullUrl_.empty();
             if (!resumeFromAuth) {
                 currentRequestId_ = platform::generateRequestId();
                 currentPullUrl_ = pullEndpointUrl_;

--- a/native/shared/SyncEngine.cpp
+++ b/native/shared/SyncEngine.cpp
@@ -782,6 +782,13 @@ void SyncEngine::handleHttpResponse(int64_t syncId, const platform::HttpResponse
             completionError = std::string("HTTP ") + std::to_string(response.statusCode);
             shouldReturn = true;
         } else {
+            // MOBILE-6770: a successful (non-auth, non-error) pull response means the
+            // current token WORKS — real progress. Reset the auth-retry budget so the
+            // maxAuthRetries cap counts only *consecutive* re-auths without progress. A
+            // long multi-page sync that hits several intermittent token expiries, each
+            // resolved by a successful re-auth, must not exhaust a cumulative budget and
+            // fail; only a persistent reject (no successful pull between re-auths) does.
+            authRetryCount_ = 0;
             emitLocked(std::string("{\"type\":\"http\",\"phase\":\"pull\",\"status\":") +
                        std::to_string(response.statusCode) + "}");
         }

--- a/native/shared/tests/SyncEngineTests.cpp
+++ b/native/shared/tests/SyncEngineTests.cpp
@@ -192,6 +192,56 @@ void test_auth_error_envelope_200_reauths_and_completes() {
                "expected sync to recover to done after a 200 auth-error envelope");
 }
 
+void test_persistent_auth_envelope_terminates_at_auth_failed() {
+    // MOBILE-6770: a *persistent* 200 auth-error envelope — the server keeps rejecting
+    // even a freshly fetched token — must terminate at auth_failed after maxAuthRetries
+    // re-auth cycles, NOT loop forever (a per-device retry storm; cf. MOBILE-6786).
+    // Regression guard: the auth-retry budget used to reset on every fetched token
+    // (setAuthToken) and on the auth-driven restart (start), so the maxAuthRetries guard
+    // never fired and the pull re-authed unbounded.
+    EventRecorder recorder;
+    auto engine = std::make_shared<watermelondb::SyncEngine>();
+    engine->setEventCallback([&](const std::string& eventJson) { recorder.add(eventJson); });
+    engine->setApplyCallback([&](const std::string&, std::string&, watermelondb::SyncChangeset&) { return true; });
+
+    // The token provider always SUCCEEDS with a fresh token — the persistent failure is
+    // the SERVER, not the provider. This is exactly the case the old resets masked.
+    static int tokenSeq = 0;
+    tokenSeq = 0;
+    engine->setAuthTokenRequestCallback([engine]() {
+        tokenSeq++;
+        engine->setAuthToken("fresh-token-" + std::to_string(tokenSeq));
+    });
+    engine->setAuthToken("token-1");
+
+    // The server sees every pull; the count must be bounded, not unbounded.
+    static int pullCount = 0;
+    pullCount = 0;
+    watermelondb::platform::setHttpHandler([](const watermelondb::platform::HttpRequest&,
+                                              std::function<void(const watermelondb::platform::HttpResponse&)> done) {
+        pullCount++;
+        watermelondb::platform::HttpResponse response;
+        response.statusCode = 200; // always the auth envelope — the token is never accepted
+        response.body =
+            "{\"errors\":[{\"extensions\":{\"code\":\"TOKEN_EXPIRED\"}}],\"data\":{}}";
+        done(response);
+    });
+
+    // maxAuthRetries defaults to 3.
+    engine->configure("{\"pullEndpointUrl\":\"https://example.com/pull\",\"connectionTag\":1}");
+    engine->start("persistent_auth_envelope");
+
+    // Pre-fix this never arrives (the loop reruns forever) and waitForContains times out.
+    expectTrue(recorder.waitForContains("\"state\":\"auth_failed\"", 3000),
+               "a persistent 200 auth envelope must terminate at auth_failed, not loop forever");
+    // maxAuthRetries=3 => 3 re-auth cycles + the pull that trips the guard = 4 pulls.
+    // A small margin catches an unbounded loop without being flaky.
+    expectTrue(pullCount <= 6,
+               ("re-auth cycles must be bounded (pullCount=" + std::to_string(pullCount) + ")").c_str());
+
+    watermelondb::platform::setHttpHandler(nullptr);
+}
+
 void test_large_payload_200_not_treated_as_auth() {
     // MOBILE-6770 hot-path guard: a large successful pull must complete normally and
     // never be treated as an auth envelope. The envelope check bails in O(1) on the
@@ -1223,6 +1273,7 @@ int main() {
     test_auth_required();
     test_auth_error_envelope_200_routes_to_auth_required();
     test_auth_error_envelope_200_reauths_and_completes();
+    test_persistent_auth_envelope_terminates_at_auth_failed();
     test_large_payload_200_not_treated_as_auth();
     test_retry_flow();
     test_cursor_pagination();

--- a/native/shared/tests/SyncEngineTests.cpp
+++ b/native/shared/tests/SyncEngineTests.cpp
@@ -242,6 +242,69 @@ void test_persistent_auth_envelope_terminates_at_auth_failed() {
     watermelondb::platform::setHttpHandler(nullptr);
 }
 
+void test_intermittent_expiry_across_pages_does_not_exhaust_budget() {
+    // MOBILE-6770 (regression guard for the loop-bound fix): a long, multi-page sync that
+    // hits MORE than maxAuthRetries *intermittent* token expiries — each individually
+    // resolved by a successful re-auth that makes progress (a page applies) — must
+    // COMPLETE, not fail at auth_failed. The auth-retry cap counts only CONSECUTIVE
+    // re-auths without an intervening successful pull; a successful pull resets it. A
+    // cumulative-per-sync cap would wrongly give up on the 4th expiry here.
+    EventRecorder recorder;
+    auto engine = std::make_shared<watermelondb::SyncEngine>();
+    engine->setEventCallback([&](const std::string& eventJson) { recorder.add(eventJson); });
+    engine->setApplyCallback([&](const std::string&, std::string&, watermelondb::SyncChangeset&) { return true; });
+
+    static int tokenSeq = 0;
+    tokenSeq = 0;
+    engine->setAuthTokenRequestCallback([engine]() {
+        tokenSeq++;
+        engine->setAuthToken("fresh-token-" + std::to_string(tokenSeq));
+    });
+    engine->setAuthToken("token-1");
+
+    // One sync, 4 pages; each page expires once (200 auth envelope) then succeeds on the
+    // re-auth retry. 4 expiries > maxAuthRetries (3), but each is followed by a successful
+    // page, so the consecutive-re-auth budget never exhausts.
+    static int callCount = 0;
+    callCount = 0;
+    watermelondb::platform::setHttpHandler([](const watermelondb::platform::HttpRequest&,
+                                              std::function<void(const watermelondb::platform::HttpResponse&)> done) {
+        watermelondb::platform::HttpResponse response;
+        response.statusCode = 200;
+        const bool expire = (callCount % 2) == 0;   // calls 0,2,4,6 expire; 1,3,5,7 succeed
+        const bool lastPage = callCount >= 7;        // final successful page ends pagination
+        if (expire) {
+            response.body = "{\"errors\":[{\"extensions\":{\"code\":\"TOKEN_EXPIRED\"}}],\"data\":{}}";
+        } else {
+            response.body = lastPage ? "{\"changes\":{},\"next\":null}"
+                                     : "{\"changes\":{},\"next\":{\"p\":1}}";
+        }
+        callCount++;
+        done(response);
+    });
+
+    engine->configure("{\"pullEndpointUrl\":\"https://example.com/pull\",\"connectionTag\":1}");
+    engine->start("intermittent_expiry");
+
+    expectTrue(
+        recorder.waitForContains("\"state\":\"done\"", 3000),
+        "a long sync with >maxAuthRetries intermittent (recovered) expiries must complete");
+
+    bool sawAuthFailed = false;
+    {
+        std::lock_guard<std::mutex> lock(recorder.mutex);
+        for (const auto& e : recorder.events) {
+            if (e.find("auth_failed") != std::string::npos) {
+                sawAuthFailed = true;
+            }
+        }
+    }
+    expectTrue(!sawAuthFailed,
+               "must not give up (auth_failed) when each expiry is individually recovered");
+
+    watermelondb::platform::setHttpHandler(nullptr);
+}
+
 void test_large_payload_200_not_treated_as_auth() {
     // MOBILE-6770 hot-path guard: a large successful pull must complete normally and
     // never be treated as an auth envelope. The envelope check bails in O(1) on the
@@ -1274,6 +1337,7 @@ int main() {
     test_auth_error_envelope_200_routes_to_auth_required();
     test_auth_error_envelope_200_reauths_and_completes();
     test_persistent_auth_envelope_terminates_at_auth_failed();
+    test_intermittent_expiry_across_pages_does_not_exhaust_budget();
     test_large_payload_200_not_treated_as_auth();
     test_retry_flow();
     test_cursor_pagination();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "7.0.4-34",
+  "version": "7.0.4-35",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@BuildHero/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "7.0.4-35",
+  "version": "7.0.4-36",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",


### PR DESCRIPTION
## What

Makes the native re-auth loop **bounded but progress-aware**, so a persistent auth
rejection terminates instead of looping forever, while a legitimately long sync that hits
intermittent (individually-recovered) token expiries still completes. Follow-up to #59
(which routed a 200 auth-error envelope into re-auth for MOBILE-6770). Two commits:

1. **Bound the loop.** `authRetryCount_` was reset to `0` on every re-auth cycle — in
   `setAuthToken` ("on successful token") and in `start` ("on new sync", which also fires
   on the auth-driven restart because `syncInFlight_` is `false` by then). So a persistent
   401 **or** 200 auth-envelope (server rejects even a fresh token) re-authed forever; the
   `authRetryCount_ >= maxAuthRetries_` guard never fired. In prod this is a per-device
   retry storm (cf. MOBILE-6786); in the synchronous C++ test harness the unbounded
   recursive re-dispatch **segfaults**. Fix: replenish the budget only on a genuinely new
   sync or a cancel — never on a fetched token or an auth-driven restart.

2. **Reset on progress.** Bounding cumulatively across a whole sync would wrongly fail a
   long, multi-page sync that hits several **intermittent** expiries, each recovered by a
   successful re-auth. Fix: reset `authRetryCount_` to `0` whenever a pull returns a
   successful (non-auth, non-error) response — real progress that the current token works —
   so the cap counts only **consecutive** re-auths without progress.

Net behavior: a persistent reject terminates at `auth_failed` after `maxAuthRetries` (3)
consecutive re-auths; single-cycle recovery and long syncs with intermittent recovered
expiries complete normally.

## Proof

`yarn test:cpp` green, including two new regression guards:
- `test_persistent_auth_envelope_terminates_at_auth_failed` — always-fresh token + a server
  that always returns the 200 envelope. **Pre-fix `sync_engine_tests` segfaults** (unbounded
  loop); post-fix it reaches `auth_failed` with a bounded pull count.
- `test_intermittent_expiry_across_pages_does_not_exhaust_budget` — one sync, 4 pages, each
  expiring once then recovering (4 recovered expiries > `maxAuthRetries`). **Fails at
  `auth_failed` with the cumulative cap alone**; passes (reaches `done`) with the
  progress-reset.

Plus the existing routing + single-cycle recovery tests from #59 remain green.

https://claude.ai/code/session_01LKSAWxdHZcsDDL5dpoHSFg
